### PR TITLE
Fix issue where g:floaterm_width and g:floaterm_height are unable to set with decimal numbers

### DIFF
--- a/autoload/floaterm.vim
+++ b/autoload/floaterm.vim
@@ -37,8 +37,8 @@ function! floaterm#toggleTerminal(height, width) abort
       endif
     endfor
 
-    let height = a:height == v:null ? float2nr(0.7*&lines) : a:height
-    let width = a:width == v:null ? float2nr(0.7*&columns) : a:width
+    let height = a:height == v:null ? float2nr(0.7*&lines) : float2nr(a:height)
+    let width = a:width == v:null ? float2nr(0.7*&columns) : float2nr(a:width)
 
     if g:floaterm_type == 'floating'
       call s:openTerminalFloating(found_bufnr, height, width)


### PR DESCRIPTION
I was setting width and height of `vim-floatterm` like this and found that it doesn't work.

## init.vim
```vim
let g:floaterm_height = &lines * 0.8
```

## Error message
```vim
Error detected while processing function floaterm#toggleTerminal[30]..<SNR>128_openTerminalFloating:
E5555: API call: 'height' key must be a positive Integer
```
## Summary
This PR fixes the issue by calling `float2nr` for arguments `a:width` and `a:height` to remove the part after decimal points from these arguments.