### PR TITLE
Allow float values for g:floaterm_{width,height}

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,11 +49,13 @@ let g:floaterm_keymap_toggle = '<F10>'
 
 #### **`g:floaterm_width`**
 
-- Default: `0.6 * &columns`
+- Type: `int` (number of columns) or `float` (between 0 and 1). If `float`, the width is relative to `&columns`.
+- Default: `0.6`
 
 #### **`g:floaterm_height`**
 
-- Default: `0.6 * &lines`
+- Type: `int` (number of lines) or `float` (between 0 and 1). If `float`, the height is relative to `&lines`.
+- Default: `0.6`
 
 #### `g:floaterm_winblend`
 

--- a/autoload/floaterm.vim
+++ b/autoload/floaterm.vim
@@ -183,14 +183,13 @@ function! g:floaterm.find_term_win() abort
 endfunction
 
 function! g:floaterm.open(found_bufnr) dict abort
-  let height =
-    \ g:floaterm_height == v:null
-    \ ? float2nr(0.6*&lines)
-    \ : float2nr(g:floaterm_height)
-  let width =
-    \ g:floaterm_width == v:null
-    \ ? float2nr(0.6*&columns)
-    \ : float2nr(g:floaterm_width)
+  let height = g:floaterm_height == v:null ? 0.6 : g:floaterm_height
+  if type(height) == v:t_float | let height = height * &lines | endif
+  let height = float2nr(height)
+
+  let width = g:floaterm_width == v:null ? 0.6 : g:floaterm_width
+  if type(width) == v:t_float | let width = width * &columns | endif
+  let width = float2nr(width)
 
   if g:floaterm_type ==# 'floating'
     let [bufnr, border_bufnr] = s:open_floating_terminal(a:found_bufnr, height, width)


### PR DESCRIPTION
If these variables are given as float numbers (between 0 and 1),
they could denote the width/height relative to the vim window.

An example usage:

```
let g:floaterm_width = 0.9    " Use 90% of the width for floaterm
```