### PR TITLE
用词错误，opacity的意思是“不透明度”

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ let g:floaterm_keymap_toggle = '<F10>'
 
 #### `g:floaterm_winblend`
 
-- Description: The opacity of the floating terminal
+- Description: The transparency of the floating terminal
 
 - Default: `0`
 


### PR DESCRIPTION
如果opacity是0的话，窗口应该完全透明。