### PR TITLE
Show the last output in the preview window

### DIFF
--- a/rplugin/python3/denite/kind/floaterm.py
+++ b/rplugin/python3/denite/kind/floaterm.py
@@ -51,9 +51,15 @@ class Kind(Base):
             self.vim.current.buffer.options["swapfile"] = False
             self.vim.current.buffer.options["bufhidden"] = "wipe"
             self.vim.current.buffer.options["buftype"] = "nofile"
-            self.vim.current.buffer[:] = self.vim.buffers[bufnr][
-                0 : self.vim.options["previewheight"]
-            ]
+
+            buf = self.vim.buffers[bufnr]
+            last_line = len(buf) - 1
+            last_non_empty_line = next(
+                filter(lambda x: buf[x] != "", range(last_line, 0, -1)), last_line
+            )
+            start = max(0, last_non_empty_line - self.vim.options["previewheight"] + 1)
+            end = last_non_empty_line + 1
+            self.vim.current.buffer[:] = buf[start:end]
 
         preview()
         self._previewed_bufnr = bufnr


### PR DESCRIPTION
I found the current build shows the top of the buffer lines in the preview window, so the shown lines will not change even after it scrolls many lines.

This commit solves this with showing the last non-empty lines of buffers.

<dl>
<dt>before</dt>
<dd><img width="745" alt="スクリーンショット 0002-02-06 21 11 09" src="https://user-images.githubusercontent.com/1239245/73937991-ad684500-4929-11ea-8bd6-b07d7804450a.png"></dd>
<dt>after</dt>
<dd><img width="744" alt="スクリーンショット 0002-02-06 21 11 59" src="https://user-images.githubusercontent.com/1239245/73937999-b48f5300-4929-11ea-9843-a8d8d11435a7.png"></dd>
</dl>

