### PR TITLE
Fix shebang to detect to be an executable in fish

### DIFF
--- a/bin/floaterm
+++ b/bin/floaterm
@@ -1,5 +1,4 @@
-# vim:ft=sh
-#! /bin/sh
+#!/bin/sh
 
 if [ -z "$1" ]; then
     echo "usage: floaterm {filename}"


### PR DESCRIPTION
It raises an error by executing `floaterm foo` in fish.

```
~ ❯❯❯ floaterm nvim.log
Failed to execute process '/path/to/vim-floaterm/bin/floaterm'. Reason:
exec: Exec format error
The file '/path/to/vim-floaterm/bin/floaterm' is marked as an executable but could not be run by the operating system.
```

This patch fixes the shebang and removes unnecessary modeline. Vim can detects as the `sh` filetype without the modeline.