### PR TITLE
fix: Always open fff in current working directory

### DIFF
--- a/autoload/floaterm/wrapper/fff.vim
+++ b/autoload/floaterm/wrapper/fff.vim
@@ -5,7 +5,7 @@
 " ============================================================================
 
 function! floaterm#wrapper#fff#() abort
-  let cmd = 'fff -p'
+  let cmd = 'fff -p ' . $PWD
   return [cmd, {'on_exit': funcref('s:fff_callback')}, v:false]
 endfunction
 


### PR DESCRIPTION
By default, `fff` [will open at the directory of the file being edited](https://github.com/dylanaraps/fff/blob/d7f5092277165b3dbcc83c358b6da123f274c947/fff#L1077), this works fine most of the time. However, if you want to edit a file outside of your project directory (like a dotfile) then `:Floaterm fff` will not show files from your project.

Ran into this issue because my vim config opens a "vim tip of the day" file when opened, and this was causing `fff` to show the wrong directory. 