### PR TITLE
fix: Only delete buffer if new file opened

### DIFF
--- a/autoload/floaterm/wrapper/fff.vim
+++ b/autoload/floaterm/wrapper/fff.vim
@@ -18,9 +18,9 @@ function! s:fff_callback(...) abort
 
     let tmp_file .= "/fff/opened_file"
     let tmp_file = fnameescape(tmp_file)
-    bd!
 
     if filereadable(tmp_file)
+        bd!
         let file_data = readfile(tmp_file)
         execute delete(tmp_file)
     else


### PR DESCRIPTION
Sorry about the drip-feed of PRs, I keep discovering issues.

This fixes an issue whereby pressing `q` in `fff` would delete
the current buffer resulting in an empty screen.

Upon exiting `fff`, if no file was opened (by pressing `l` or `enter`)
then the vimmer should be returned to the existing buffer.