### PR TITLE
Always open the current directory in ranger

### DIFF
--- a/autoload/floaterm/wrapper/ranger.vim
+++ b/autoload/floaterm/wrapper/ranger.vim
@@ -6,7 +6,7 @@
 
 function! floaterm#wrapper#ranger#() abort
   let s:ranger_tmpfile = tempname()
-  let cmd = 'ranger --choosefiles=' . s:ranger_tmpfile
+  let cmd = 'ranger ' . $PWD . ' --choosefiles=' . s:ranger_tmpfile
   return [cmd, {'on_exit': funcref('s:ranger_callback')}, v:false]
 endfunction
 


### PR DESCRIPTION
Ranger was opening a cached directory path, meaning that when you invoke `:FloatermNew ranger` it would open at the path of the last project you used it in. 