### PR TITLE
Open ranger at the path of the current file, maintain working directory

### DIFF
--- a/autoload/floaterm/wrapper/fff.vim
+++ b/autoload/floaterm/wrapper/fff.vim
@@ -5,7 +5,10 @@
 " ============================================================================
 
 function! floaterm#wrapper#fff#() abort
-  let cmd = 'fff -p ' . $PWD
+  let original_dir = getcwd()
+  lcd %:p:h
+  let cmd = 'fff -p ' . getcwd()
+  exe "lcd " . original_dir
   return [cmd, {'on_exit': funcref('s:fff_callback')}, v:false]
 endfunction
 

--- a/autoload/floaterm/wrapper/ranger.vim
+++ b/autoload/floaterm/wrapper/ranger.vim
@@ -6,7 +6,10 @@
 
 function! floaterm#wrapper#ranger#() abort
   let s:ranger_tmpfile = tempname()
-  let cmd = 'ranger ' . $PWD . ' --choosefiles=' . s:ranger_tmpfile
+  let s:original_dir = getcwd()
+  lcd %:p:h
+  let cmd = 'ranger ' . getcwd() . ' --choosefiles=' . s:ranger_tmpfile
+  exe "lcd " . s:original_dir
   return [cmd, {'on_exit': funcref('s:ranger_callback')}, v:false]
 endfunction
 

--- a/autoload/floaterm/wrapper/ranger.vim
+++ b/autoload/floaterm/wrapper/ranger.vim
@@ -6,10 +6,10 @@
 
 function! floaterm#wrapper#ranger#() abort
   let s:ranger_tmpfile = tempname()
-  let s:original_dir = getcwd()
+  let original_dir = getcwd()
   lcd %:p:h
   let cmd = 'ranger ' . getcwd() . ' --choosefiles=' . s:ranger_tmpfile
-  exe "lcd " . s:original_dir
+  exe "lcd " . original_dir
   return [cmd, {'on_exit': funcref('s:ranger_callback')}, v:false]
 endfunction
 


### PR DESCRIPTION
What this does is open ranger at the path of the current file / directory from vim's perspective. It also respects the vim-user's working directory setting (`s:original_dir`), which can be set by the .vimrc, e.g.

`autocmd VimEnter * silent! lcd %:p:h " Set working directory to current file / dir from perspective of vim`

`autocmd VimEnter * silent! lcd $PWD " Set working directory to current file / dir from perspective of shell`
