### PR TITLE
fix: Fix current directory issue in lf.vim

### DIFF
--- a/autoload/floaterm/wrapper/lf.vim
+++ b/autoload/floaterm/wrapper/lf.vim
@@ -8,7 +8,7 @@ function! floaterm#wrapper#lf#() abort
   let tmp_file = s:lf_tmp_file()
   let original_dir = getcwd()
   lcd %:p:h
-  let cmd = 'lf -selection-path=' . tmp_file
+  let cmd = 'lf -selection-path=' . tmp_file . ' ' . getcwd()
   exe "lcd " . original_dir
   return [cmd, {'on_exit': funcref('s:lf_callback')}, v:false]
 endfunction


### PR DESCRIPTION
Realised this code wasn't actually working. 

The directory of the current file is cached in vim using `lcd %:p:h`, but without `getcwd()`, `lf` just opens at `$PWD`.