### PR TITLE
Added Vifm wrapper

### DIFF
--- a/README.md
+++ b/README.md
@@ -228,9 +228,9 @@ command! Ranger FloatermNew ranger
 
 ![](https://user-images.githubusercontent.com/20282795/74800026-2e054900-530d-11ea-8e2a-67168a9532a9.gif)
 
-### Use as an Vifm plugin
+### Use as a Vifm plugin
 
-There is also an [vifm wrapper](./autoload/floaterm/wrapper/vifm.vim)
+There is also a [vifm wrapper](./autoload/floaterm/wrapper/vifm.vim)
 
 Try `:FloatermNew vifm` or define a new command:
 

--- a/README.md
+++ b/README.md
@@ -238,6 +238,8 @@ Try `:FloatermNew vifm` or define a new command:
 command! Vifm FloatermNew vifm
 ```
 
+![](https://user-images.githubusercontent.com/43941510/77135898-304ef480-6abf-11ea-973f-515d448ec153.gif)
+
 ### Use as a Python REPL plugin
 
 Use `:FloatermNew python` to open a python REPL. After that you can use `:FloatermSend` to send lines to the Python interactive shell.

--- a/README.md
+++ b/README.md
@@ -238,7 +238,7 @@ Try `:FloatermNew vifm` or define a new command:
 command! Vifm FloatermNew vifm
 ```
 
-![](https://user-images.githubusercontent.com/43941510/77135898-304ef480-6abf-11ea-973f-515d448ec153.gif)
+![](https://user-images.githubusercontent.com/43941510/77137476-3c888100-6ac2-11ea-90f2-2345c881aa8f.gif)
 
 ### Use as a Python REPL plugin
 

--- a/README.md
+++ b/README.md
@@ -228,6 +228,16 @@ command! Ranger FloatermNew ranger
 
 ![](https://user-images.githubusercontent.com/20282795/74800026-2e054900-530d-11ea-8e2a-67168a9532a9.gif)
 
+### Use as an Vifm plugin
+
+There is also an [vifm wrapper](./autoload/floaterm/wrapper/vifm.vim)
+
+Try `:FloatermNew vifm` or define a new command:
+
+```vim
+command! Vifm FloatermNew vifm
+```
+
 ### Use as a Python REPL plugin
 
 Use `:FloatermNew python` to open a python REPL. After that you can use `:FloatermSend` to send lines to the Python interactive shell.

--- a/autoload/floaterm/wrapper/vifm.vim
+++ b/autoload/floaterm/wrapper/vifm.vim
@@ -8,7 +8,6 @@ function! floaterm#wrapper#vifm#() abort
   let s:vifm_tmpfile = tempname()
   let original_dir = expand("%:p:h")
   let cmd = 'vifm ' . original_dir . ' --choose-files ' . s:vifm_tmpfile
-  " endif
   return [cmd, {'on_exit': funcref('s:vifm_callback')}, v:false]
 endfunction
 

--- a/autoload/floaterm/wrapper/vifm.vim
+++ b/autoload/floaterm/wrapper/vifm.vim
@@ -1,0 +1,25 @@
+" ============================================================================
+" FileName: vifm.vim
+" Author: kazhala <kevin7441@gmail.com>
+" GitHub: https://github.com/kazhala
+" ============================================================================
+
+function! floaterm#wrapper#vifm#() abort
+  let s:vifm_tmpfile = tempname()
+  let original_dir = expand("%:p:h")
+  exe "lcd " . original_dir
+  let cmd = 'vifm . --choose-files ' . s:vifm_tmpfile
+  return [cmd, {'on_exit': funcref('s:vifm_callback')}, v:false]
+endfunction
+
+function! s:vifm_callback(...) abort
+  if filereadable(s:vifm_tmpfile)
+    let filenames = readfile(s:vifm_tmpfile)
+    if !empty(filenames)
+      call floaterm#hide()
+      for filename in filenames
+        execute g:floaterm_open_command . ' ' . fnameescape(filename)
+      endfor
+    endif
+  endif
+endfunction

--- a/autoload/floaterm/wrapper/vifm.vim
+++ b/autoload/floaterm/wrapper/vifm.vim
@@ -6,9 +6,12 @@
 
 function! floaterm#wrapper#vifm#() abort
   let s:vifm_tmpfile = tempname()
-  let original_dir = expand("%:p:h")
-  exe "lcd " . original_dir
-  let cmd = 'vifm . --choose-files ' . s:vifm_tmpfile
+  let original_dir = expand("%:p")
+  if empty(original_dir)
+    let cmd = 'vifm . --choose-files ' . s:vifm_tmpfile
+  else
+    let cmd = 'vifm ' . original_dir . '--choose-files ' . s:vifm_tmpfile
+  endif
   return [cmd, {'on_exit': funcref('s:vifm_callback')}, v:false]
 endfunction
 

--- a/autoload/floaterm/wrapper/vifm.vim
+++ b/autoload/floaterm/wrapper/vifm.vim
@@ -6,12 +6,9 @@
 
 function! floaterm#wrapper#vifm#() abort
   let s:vifm_tmpfile = tempname()
-  let original_dir = expand("%:p")
-  if empty(original_dir)
-    let cmd = 'vifm . --choose-files ' . s:vifm_tmpfile
-  else
-    let cmd = 'vifm ' . original_dir . '--choose-files ' . s:vifm_tmpfile
-  endif
+  let original_dir = expand("%:p:h")
+  let cmd = 'vifm ' . original_dir . ' --choose-files ' . s:vifm_tmpfile
+  " endif
   return [cmd, {'on_exit': funcref('s:vifm_callback')}, v:false]
 endfunction
 


### PR DESCRIPTION
Another terminal file manager wrapper...My personal favourite file manager has been [vifm](https://github.com/vifm/vifm). It does have a vim plugin but doesn't provide a way to open in floating windows, maybe I missed something in their doc. Looking at the wrapper example, I figured making a floaterm wrapper is a much easier job.

I've read through the doc of the added new wrapper and made some small adjustment based on the ranger wrapper. The reason I've used the `expand("%:p:h")` instead of `getcwd()` is that I'm trying to manipulate the same behaviour of their vim plugin (Open the manager and set the path to current file path instead of root path).

If you are interested in having a look at vifm, here is a great intro video [vifm - The Terminal File Manager For The Vim-Centric User](https://www.youtube.com/watch?v=47QYCa8AYG4), it's on youtube, you'll need VPN