### PR TITLE
add ability to name floaterm terminals

### DIFF
--- a/autoload/floaterm.vim
+++ b/autoload/floaterm.vim
@@ -115,7 +115,7 @@ function! floaterm#toggle(...)  abort
   else
     let termname = get(a:, 1, '')
     if termname != ''
-      let bufnr = bufnr('floaterm://' . termname)
+      let bufnr = floaterm#terminal#get_bufnr(termname)
       echo bufnr
       if bufnr == -1
         call floaterm#util#show_msg('No floaterm found with name: ' . termname, 'error')
@@ -163,17 +163,26 @@ function! floaterm#hide() abort
   endwhile
 endfunction
 
-function! floaterm#send(bang, startlnum, endlnum) abort
+function! floaterm#send(bang, startlnum, endlnum, ...) abort
   if &filetype ==# 'floaterm'
     let msg = "FloatermSend can't be used in the floaterm window"
     call floaterm#util#show_msg(msg, 'warning')
     return
   endif
 
-  let bufnr = floaterm#buflist#find_curr()
-  if bufnr == -1
-    let bufnr = floaterm#new()
+  let termname = get(a:, 1, '')
+  if termname != ''
+    let bufnr = floaterm#terminal#get_bufnr(termname)
+    if bufnr == -1
+      call floaterm#util#show_msg('No floaterm found with name: ' . termname, 'error')
+    endif
+  else
+    let bufnr = floaterm#buflist#find_curr()
+    if bufnr == -1
+      let bufnr = floaterm#new()
+    endif
   endif
+
 
   let linelist = []
   if a:bang ==# '!'

--- a/autoload/floaterm.vim
+++ b/autoload/floaterm.vim
@@ -116,7 +116,6 @@ function! floaterm#toggle(...)  abort
     let termname = get(a:, 1, '')
     if termname != ''
       let bufnr = floaterm#terminal#get_bufnr(termname)
-      echo bufnr
       if bufnr == -1
         call floaterm#util#show_msg('No floaterm found with name: ' . termname, 'error')
         return

--- a/autoload/floaterm.vim
+++ b/autoload/floaterm.vim
@@ -109,10 +109,22 @@ function! floaterm#curr() abort
   return curr_bufnr
 endfunction
 
-function! floaterm#toggle()  abort
+function! floaterm#toggle(...)  abort
   if &filetype ==# 'floaterm'
     hide
   else
+    let termname = get(a:, 1, '')
+    if termname != ''
+      let bufnr = bufnr('floaterm://' . termname)
+      echo bufnr
+      if bufnr == -1
+        call floaterm#util#show_msg('No floaterm found with name: ' . termname, 'error')
+        return
+      endif
+      call floaterm#terminal#open_existing(bufnr)
+      return
+    endif
+
     let found_winnr = s:find_term_win()
     if found_winnr > 0
       execute found_winnr . 'wincmd w'

--- a/autoload/floaterm/cmdline.vim
+++ b/autoload/floaterm/cmdline.vim
@@ -26,3 +26,17 @@ function! floaterm#cmdline#complete(arg_lead, cmd_line, cursor_pos) abort
     return filter(candidates, 'v:val[:len(prefix) - 1] ==# prefix')
   endif
 endfunction
+
+function! floaterm#cmdline#floaterm_names(arg_lead, cmd_line, cursor_pos)
+  let buflist = floaterm#buflist#gather()
+  let ret = []
+  let pattern = '^floaterm://'
+  for bufnr in buflist
+    let name = getbufinfo(bufnr)[0].name
+    let termname = substitute(name, pattern, '', '')
+    if name =~ pattern && match(termname, a:arg_lead) != -1
+      call add(ret, termname)
+    endif
+  endfor
+  return ret
+endfunction

--- a/autoload/floaterm/terminal.vim
+++ b/autoload/floaterm/terminal.vim
@@ -82,6 +82,12 @@ function! floaterm#terminal#open(bufnr, cmd, opts, window_opts) abort
     endif
   endif
   call setbufvar(bufnr, 'window_opts', a:window_opts)
+  let term_name = get(a:window_opts, 'name', '')
+  if term_name != ''
+    let term_name = 'floaterm://' . term_name
+    execute 'file ' . term_name
+  endif
+  
   call s:on_open()
   return bufnr
 endfunction

--- a/autoload/floaterm/terminal.vim
+++ b/autoload/floaterm/terminal.vim
@@ -117,3 +117,7 @@ function! floaterm#terminal#send(bufnr, cmds) abort
     call ch_sendraw(ch, join(a:cmds, newline) . newline)
   endif
 endfunction
+
+function! floaterm#terminal#get_bufnr(termname) abort
+  return bufnr('floaterm://' . a:termname)
+endfunction

--- a/autoload/floaterm/terminal.vim
+++ b/autoload/floaterm/terminal.vim
@@ -81,19 +81,19 @@ function! floaterm#terminal#open(bufnr, cmd, opts, window_opts) abort
       wincmd J
     endif
   endif
-  call setbufvar(bufnr, 'window_opts', a:window_opts)
+  call setbufvar(bufnr, 'floaterm_window_opts', a:window_opts)
   let term_name = get(a:window_opts, 'name', '')
   if term_name != ''
     let term_name = 'floaterm://' . term_name
     execute 'file ' . term_name
   endif
-  
+
   call s:on_open()
   return bufnr
 endfunction
 
 function! floaterm#terminal#open_existing(bufnr) abort
-  let window_opts = getbufvar(a:bufnr, 'window_opts', {})
+  let window_opts = getbufvar(a:bufnr, 'floaterm_window_opts', {})
   call floaterm#terminal#open(a:bufnr, '', {}, window_opts)
 endfunction
 

--- a/plugin/floaterm.vim
+++ b/plugin/floaterm.vim
@@ -26,7 +26,7 @@ command! -nargs=0                    FloatermPrev   call floaterm#prev()
 command! -nargs=0                    FloatermNext   call floaterm#next()
 command! -nargs=?                    FloatermToggle call floaterm#toggle(<f-args>)
 command! -nargs=0                    FloatermInfo   call floaterm#buflist#info()
-command! -nargs=0 -range -bang       FloatermSend   call floaterm#send('<bang>', <line1>, <line2>)
+command! -nargs=? -range -bang       FloatermSend   call floaterm#send('<bang>', <line1>, <line2>, <f-args>)
 command! -nargs=* -complete=customlist,floaterm#cmdline#complete
                                    \ FloatermNew    call s:new_floaterm(<f-args>)
 

--- a/plugin/floaterm.vim
+++ b/plugin/floaterm.vim
@@ -24,9 +24,11 @@ let g:floaterm_gitcommit     = get(g:, 'floaterm_gitcommit', v:null)
 
 command! -nargs=0                    FloatermPrev   call floaterm#prev()
 command! -nargs=0                    FloatermNext   call floaterm#next()
-command! -nargs=?                    FloatermToggle call floaterm#toggle(<f-args>)
+command! -nargs=? -complete=customlist,floaterm#cmdline#floaterm_names
+                                   \ FloatermToggle call floaterm#toggle(<f-args>)
 command! -nargs=0                    FloatermInfo   call floaterm#buflist#info()
-command! -nargs=? -range -bang       FloatermSend   call floaterm#send('<bang>', <line1>, <line2>, <f-args>)
+command! -nargs=? -range -bang -complete=customlist,floaterm#cmdline#floaterm_names
+                                   \ FloatermSend   call floaterm#send('<bang>', <line1>, <line2>, <f-args>)
 command! -nargs=* -complete=customlist,floaterm#cmdline#complete
                                    \ FloatermNew    call s:new_floaterm(<f-args>)
 

--- a/plugin/floaterm.vim
+++ b/plugin/floaterm.vim
@@ -24,7 +24,7 @@ let g:floaterm_gitcommit     = get(g:, 'floaterm_gitcommit', v:null)
 
 command! -nargs=0                    FloatermPrev   call floaterm#prev()
 command! -nargs=0                    FloatermNext   call floaterm#next()
-command! -nargs=0                    FloatermToggle call floaterm#toggle()
+command! -nargs=?                    FloatermToggle call floaterm#toggle(<f-args>)
 command! -nargs=0                    FloatermInfo   call floaterm#buflist#info()
 command! -nargs=0 -range -bang       FloatermSend   call floaterm#send('<bang>', <line1>, <line2>)
 command! -nargs=* -complete=customlist,floaterm#cmdline#complete


### PR DESCRIPTION
```
FloatermNew name='test1'
FloatermToggle test1
FloatermSend test1
```

Backwards compatibility is maintained.

Closes #69 