### PR TITLE
Added quotes around file paths passed to vifm from wrapper

### DIFF
--- a/autoload/floaterm/wrapper/vifm.vim
+++ b/autoload/floaterm/wrapper/vifm.vim
@@ -11,11 +11,11 @@ function! floaterm#wrapper#vifm#(cmd) abort
   lcd %:p:h
 
   let cmdlist = split(a:cmd)
-  let cmd = 'vifm --choose-files ' . s:vifm_tmpfile
+  let cmd = 'vifm --choose-files "' . s:vifm_tmpfile . '"'
   if len(cmdlist) > 1
     let cmd .= ' ' . join(cmdlist[1:], ' ')
   else
-    let cmd .= ' ' . getcwd()
+    let cmd .= ' "' . getcwd() . '"'
   endif
 
   exe "lcd " . original_dir


### PR DESCRIPTION
Currently, bare file paths are passed to vifm from the vifm.vim wrapper, which can cause errors when a file path contains spaces.

This surrounds all paths passed to vifm with quotes in order to prevent this. It would probably be wise to mimic this behaviour across all wrappers, however since I haven't tested this with any of the other external programs this package provides wrappers for I thought it best to leave it at vifm.vim.