### PR TITLE
Added quotes around file paths passed to all external file managers from wrappers

### DIFF
--- a/autoload/floaterm/wrapper/fff.vim
+++ b/autoload/floaterm/wrapper/fff.vim
@@ -14,7 +14,7 @@ function! floaterm#wrapper#fff#(cmd) abort
   if len(cmdlist) > 1
     let cmd .= ' ' . join(cmdlist[1:], ' ')
   else
-    let cmd .= ' ' . getcwd()
+    let cmd .= ' "' . getcwd() . '"'
   endif
 
   exe "lcd " . original_dir

--- a/autoload/floaterm/wrapper/lf.vim
+++ b/autoload/floaterm/wrapper/lf.vim
@@ -11,11 +11,11 @@ function! floaterm#wrapper#lf#(cmd) abort
   lcd %:p:h
 
   let cmdlist = split(a:cmd)
-  let cmd = 'lf -selection-path=' . s:lf_tmpfile
+  let cmd = 'lf -selection-path="' . s:lf_tmpfile . '"'
   if len(cmdlist) > 1
     let cmd .= ' ' . join(cmdlist[1:], ' ')
   else
-    let cmd .= ' ' . getcwd()
+    let cmd .= ' "' . getcwd() . '"'
   endif
 
   exe "lcd " . original_dir

--- a/autoload/floaterm/wrapper/nnn.vim
+++ b/autoload/floaterm/wrapper/nnn.vim
@@ -11,11 +11,11 @@ function! floaterm#wrapper#nnn#(cmd) abort
   lcd %:p:h
 
   let cmdlist = split(a:cmd)
-  let cmd = 'nnn -p ' . s:nnn_tmpfile
+  let cmd = 'nnn -p "' . s:nnn_tmpfile . '"'
   if len(cmdlist) > 1
     let cmd .= ' ' . join(cmdlist[1:], ' ')
   else
-    let cmd .= ' ' . getcwd()
+    let cmd .= ' "' . getcwd() . '"'
   endif
 
   exe "lcd " . original_dir

--- a/autoload/floaterm/wrapper/ranger.vim
+++ b/autoload/floaterm/wrapper/ranger.vim
@@ -11,14 +11,14 @@ function! floaterm#wrapper#ranger#(cmd) abort
   lcd %:p:h
 
   let cmdlist = split(a:cmd)
-  let cmd = 'ranger --choosefiles=' . s:ranger_tmpfile
+  let cmd = 'ranger --choosefiles="' . s:ranger_tmpfile . '"'
   if len(cmdlist) > 1
     let cmd .= ' ' . join(cmdlist[1:], ' ')
   else
     if expand('%:p') != ''
       let cmd .= ' --selectfile="' . expand('%:p') . '"'
     else
-      let cmd .= ' ' . getcwd()
+    let cmd .= ' "' . getcwd() . '"'
     endif
   endif
 


### PR DESCRIPTION
Following on from #107 I added quotes to the file paths in all other other wrappers. Not tested these but I don't see how it would cause an issue and should fix any potential issues with passing paths containing spaces.