### PR TITLE
Add `!` flag for FloatermHide/FloatermShow/FloatermKill/FloatermToggl…

### DIFF
--- a/autoload/floaterm.vim
+++ b/autoload/floaterm.vim
@@ -88,7 +88,21 @@ endfunction
 " ----------------------------------------------------------------------------
 " toggle on/off the floaterm named `name`
 " ----------------------------------------------------------------------------
-function! floaterm#toggle(...)  abort
+function! floaterm#toggle(bang, ...)  abort
+  if a:bang
+    let found_winnr = floaterm#window#find_floaterm_window()
+    if found_winnr > 0
+      for bufnr in floaterm#buflist#gather()
+        call floaterm#window#hide_floaterm(bufnr)
+      endfor
+    else
+      for bufnr in floaterm#buflist#gather()
+        call floaterm#terminal#open_existing(bufnr)
+      endfor
+    endif
+    return
+  endif
+
   let name = get(a:, 1, '')
   if name != ''
     let bufnr = floaterm#terminal#get_bufnr(name)
@@ -162,7 +176,14 @@ function! floaterm#curr() abort
   return curr_bufnr
 endfunction
 
-function! floaterm#kill(...) abort
+function! floaterm#kill(bang, ...) abort
+  if a:bang
+    for bufnr in floaterm#buflist#gather()
+      call floaterm#terminal#kill(bufnr)
+    endfor
+    return
+  endif
+
   let name = get(a:, 1, '')
   if !empty(name)
     let bufnr = floaterm#terminal#get_bufnr(name)
@@ -171,26 +192,18 @@ function! floaterm#kill(...) abort
   endif
   if bufnr == -1
     call floaterm#util#show_msg('The floaterm does not exist', 'warning')
-    return
-  endif
-  call floaterm#window#hide_floaterm(bufnr)
-  if has('nvim')
-    let jobid = getbufvar(bufnr, '&channel')
-    if jobwait([jobid], 0)[0] == -1
-      call jobstop(jobid)
-    endif
   else
-    let job = term_getjob(bufnr)
-    if job_status(job) !=# 'dead'
-      call job_stop(job)
-    endif
-  endif
-  if bufexists(bufnr)
-    execute bufnr . 'bwipeout!'
+    call floaterm#terminal#kill(bufnr)
   endif
 endfunction
 
-function! floaterm#show(...) abort
+function! floaterm#show(bang, ...) abort
+  if a:bang
+    for bufnr in floaterm#buflist#gather()
+      call floaterm#terminal#open_existing(bufnr)
+    endfor
+  endif
+
   let name = get(a:, 1, '')
   if !empty(name)
     let bufnr = floaterm#terminal#get_bufnr(name)
@@ -204,7 +217,14 @@ function! floaterm#show(...) abort
   endif
 endfunction
 
-function! floaterm#hide(...) abort
+function! floaterm#hide(bang, ...) abort
+  if a:bang
+    for bufnr in floaterm#buflist#gather()
+      call floaterm#window#hide_floaterm(bufnr)
+    endfor
+    return
+  endif
+
   let name = get(a:, 1, '')
   if !empty(name)
     let bufnr = floaterm#terminal#get_bufnr(name)

--- a/autoload/floaterm/terminal.vim
+++ b/autoload/floaterm/terminal.vim
@@ -212,3 +212,21 @@ endfunction
 function! floaterm#terminal#get_bufnr(termname) abort
   return bufnr('floaterm://' . a:termname)
 endfunction
+
+function! floaterm#terminal#kill(bufnr) abort
+  call floaterm#window#hide_floaterm(a:bufnr)
+  if has('nvim')
+    let jobid = getbufvar(a:bufnr, '&channel')
+    if jobwait([jobid], 0)[0] == -1
+      call jobstop(jobid)
+    endif
+  else
+    let job = term_getjob(a:bufnr)
+    if job_status(job) !=# 'dead'
+      call job_stop(job)
+    endif
+  endif
+  if bufexists(a:bufnr)
+    execute a:bufnr . 'bwipeout!'
+  endif
+endfunction

--- a/plugin/floaterm.vim
+++ b/plugin/floaterm.vim
@@ -29,18 +29,18 @@ let g:floaterm_keymap_show   = get(g:, 'floaterm_keymap_show', v:null)
 let g:floaterm_keymap_kill   = get(g:, 'floaterm_keymap_kill', v:null)
 let g:floaterm_keymap_toggle = get(g:, 'floaterm_keymap_toggle', v:null)
 
-command! -nargs=* -complete=customlist,floaterm#cmdline#complete -bang
+command! -nargs=* -bang -complete=customlist,floaterm#cmdline#complete
                           \ FloatermNew    call floaterm#run('new', <bang>0, <f-args>)
-command! -nargs=* -complete=customlist,floaterm#cmdline#complete
+command! -nargs=* -bang -complete=customlist,floaterm#cmdline#complete
                           \ FloatermUpdate call floaterm#run('update', 0, <f-args>)
-command! -nargs=? -complete=customlist,floaterm#cmdline#floaterm_names
-                          \ FloatermShow   call floaterm#show(<f-args>)
-command! -nargs=? -complete=customlist,floaterm#cmdline#floaterm_names
-                          \ FloatermHide   call floaterm#hide(<f-args>)
-command! -nargs=? -complete=customlist,floaterm#cmdline#floaterm_names
-                          \ FloatermKill   call floaterm#kill(<f-args>)
-command! -nargs=? -complete=customlist,floaterm#cmdline#floaterm_names
-                          \ FloatermToggle call floaterm#toggle(<f-args>)
+command! -nargs=? -bang -complete=customlist,floaterm#cmdline#floaterm_names
+                          \ FloatermShow   call floaterm#show(<bang>0, <f-args>)
+command! -nargs=? -bang -complete=customlist,floaterm#cmdline#floaterm_names
+                          \ FloatermHide   call floaterm#hide(<bang>0, <f-args>)
+command! -nargs=? -bang -complete=customlist,floaterm#cmdline#floaterm_names
+                          \ FloatermKill   call floaterm#kill(<bang>0, <f-args>)
+command! -nargs=? -bang -complete=customlist,floaterm#cmdline#floaterm_names
+                          \ FloatermToggle call floaterm#toggle(<bang>0, <f-args>)
 command! -nargs=? -range -bang -complete=customlist,floaterm#cmdline#floaterm_names2
                           \ FloatermSend   call floaterm#send(<bang>0, <range>, <line1>, <line2>, <q-args>)
 command! -nargs=0           FloatermPrev   call floaterm#prev()

--- a/test/test_command.vader
+++ b/test/test_command.vader
@@ -42,5 +42,5 @@ Execute(FloatermSend):
 
 Execute (Exit):
   stopinsert
-  call floaterm#hide()
+  call floaterm#hide(1)
   sleep 100m

--- a/test/test_floaterm_size.vader
+++ b/test/test_floaterm_size.vader
@@ -23,5 +23,5 @@ Execute(Test floaterm winopts before and after FloatermToggle):
 
 Execute(Exit):
   stopinsert
-  call floaterm#hide()
+  call floaterm#hide(1)
   sleep 100m

--- a/test/test_function.vader
+++ b/test/test_function.vader
@@ -70,5 +70,5 @@ Execute(Test floaterm#cmdline#floaterm_names2):
 
 Execute(Exit):
   stopinsert
-  call floaterm#hide()
+  call floaterm#hide(1)
   sleep 100m

--- a/test/test_keymap.vader
+++ b/test/test_keymap.vader
@@ -38,5 +38,5 @@ Then:
 
 Execute(Exit):
   stopinsert
-  call floaterm#hide()
+  call floaterm#hide(1)
   sleep 100m


### PR DESCRIPTION
Add `!` flag for FloatermHide/FloatermShow/FloatermKill/FloatermToggle, allow to execute on all floaterms.

Attemp to fix #121.

TODO:
- [ ] Remove API doc in README
- [ ] Fix the bug mentioned in #121