### PR TITLE
Fix cmdline option parser #176

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ If you've opened multiple floaterm instances, they will be attached to a double-
 
 - If `!` exists, run program in `$SHELL`. Try `:FloatermNew python` and `:FloatermNew! python` to learn about the difference.
 - If `cmd` doesn't exist, open `$SHELL`.
-- The `options` is formed as `--key[=value]`, it is used to specify some attributes of the floaterm instance, including `height`, `width`, `wintype`, `position`, `name` and `autoclose`.
+- The `options` is formed as `--key=value`, it is used to specify some attributes of the floaterm instance, including `height`, `width`, `wintype`, `position`, `name` and `autoclose`.
   - `name` name of the floaterm
   - `height` see `g:floaterm_height`
   - `width` see `g:floaterm_width`

--- a/autoload/floaterm/cmdline.vim
+++ b/autoload/floaterm/cmdline.vim
@@ -19,7 +19,7 @@ function! floaterm#cmdline#parse(arglist) abort
         let opt = split(arg, '=')
         if len(opt) != 2
           call floaterm#util#show_msg('No value given to option: ' . opt[0], 'warning')
-          continue
+          return
         endif
         let [key, value] = [opt[0][2:], opt[1]]
         if index(['height', 'width', 'autoclose'], key) > -1

--- a/autoload/floaterm/cmdline.vim
+++ b/autoload/floaterm/cmdline.vim
@@ -15,18 +15,17 @@ function! floaterm#cmdline#parse(arglist) abort
   if a:arglist != []
     let c = 0
     for arg in a:arglist
-      if arg =~ '^--.*$'
+      if arg =~ '^--\S.*=.*$'
         let opt = split(arg, '=')
-        if len(opt) == 2
-          let [key, value] = [opt[0][2:], opt[1]]
-          if index(['height', 'width', 'autoclose'], key) > -1
-            let value = eval(value)
-          endif
-          let opts[key] = value
-        else
-          let key = opt[0][2:]
-          let opts[key] = v:true
+        if len(opt) != 2
+          call floaterm#util#show_msg('No value given to option: ' . opt[0], 'warning')
+          continue
         endif
+        let [key, value] = [opt[0][2:], opt[1]]
+        if index(['height', 'width', 'autoclose'], key) > -1
+          let value = eval(value)
+        endif
+        let opts[key] = value
       else
         let cmd = s:expand(join(a:arglist[c:]))
         break

--- a/autoload/floaterm/cmdline.vim
+++ b/autoload/floaterm/cmdline.vim
@@ -18,7 +18,7 @@ function! floaterm#cmdline#parse(arglist) abort
       if arg =~ '^--\S.*=.*$'
         let opt = split(arg, '=')
         if len(opt) != 2
-          call floaterm#util#show_msg('No value given to option: ' . opt[0], 'warning')
+          call floaterm#util#show_msg('Argument Error: No value given to option: ' . opt[0], 'error')
           return
         endif
         let [key, value] = [opt[0][2:], opt[1]]


### PR DESCRIPTION
This implementation behaves as follows:
- Any option like `--opt` is not parsed by floaterm, it is given to the `cmd`
- Any option like `--opt=` throws a warning and doesn't set any value for `b:floaterm_opts[opt]`

Note that in the second case the floaterm is still opened successfully, but without setting the value of `opt`. Let me know what you think, maybe you prefer to error and abort completely?