### PR TITLE
Fix floaterm#toggle with a name parameter

### DIFF
--- a/autoload/floaterm.vim
+++ b/autoload/floaterm.vim
@@ -110,7 +110,7 @@ function! floaterm#toggle(bang, bufnr, name)  abort
   endif
 
   if bufnr == -1
-    call floaterm#new(a:bang, '', {'name': a:name}, {})
+    call floaterm#new(a:bang, '', {}, {'name': a:name})
   elseif bufnr == 0
     if &filetype == 'floaterm'
       call floaterm#window#hide_floaterm(bufnr('%'))

--- a/test/test_commands/test_FloatermToggle.vader
+++ b/test/test_commands/test_FloatermToggle.vader
@@ -39,7 +39,7 @@ Execute([N]FloatermToggle):
   execute bufnr2 . 'FloatermToggle'
   AssertEqual bufnr2, bufnr()
 
-Execute(FloatermToggle --name):
+Execute(FloatermToggle name, named floaterm exists):
   FloatermKill!
   FloatermNew --name=ft1
   FloatermToggle
@@ -47,8 +47,12 @@ Execute(FloatermToggle --name):
   FloatermToggle
 
   FloatermToggle ft1
+  AssertEqual 'ft1', b:floaterm_opts['name']
   FloatermToggle ft2
-  FloatermKill!
+  AssertEqual 'ft2', b:floaterm_opts['name']
+  FloatermToggle ft3
+  AssertEqual 'ft3', b:floaterm_opts['name']
+
 
 Execute (Exit):
   stopinsert


### PR DESCRIPTION
Currently, the `floaterm#terminal#toggle` method doesn't work when a named argument is passed (It will always create a new buffer, even if one has already been created). On inspection, this seems to be an issue with the order of arguments passed to `floaterm#new` - the `jobopts` and `opts` arguments seem to be switched. Reversing them fixes the issue.