### PR TITLE
Fix `floaterm#window#hide_floaterm` when `g:floaterm_wintype = 'normal'`

### DIFF
--- a/autoload/floaterm/window.vim
+++ b/autoload/floaterm/window.vim
@@ -315,17 +315,30 @@ function! floaterm#window#hide_floaterm(bufnr) abort
     if !s:winexists(winid) | return | endif
     call nvim_win_close(winid, v:true)
   else
+    let l:bufnr_to_winnr_dic = {}
+    for i in range(1, winnr('$'))
+      let l:bufnr_to_winnr_dic[winbufnr(i)] = i
+    endfor
+
     if exists('*win_gettype')
       if win_gettype() == 'popup'
         call popup_close(winid)
       else
-        execute a:bufnr . 'hide'
+        try
+          let l:winnr = l:bufnr_to_winnr_dic[a:bufnr]
+          execute l:winnr . 'hide'
+        catch
+        endtry
       endif
     else
       try      " there should be a function like `win_type()`
         call popup_close(winid)
       catch
-        execute a:bufnr . 'hide'
+        try
+          let l:winnr = l:bufnr_to_winnr_dic[a:bufnr]
+          execute l:winnr . 'hide'
+        catch
+        endtry
       endtry
     endif
   endif


### PR DESCRIPTION
The `hide` function accepts `winnr` instead of `bufnr`.
Therefore, I implemented the logic to convert from `bufnr` to `winnr`.

modified:   autoload/floaterm/window.vim

![terms](https://user-images.githubusercontent.com/4811459/96363535-ff779080-116f-11eb-8837-b2345057bb09.gif)
