### PR TITLE
Fix Codeblock in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ will open a new `floating` floaterm instance named `floaterm1` running `ranger -
 The following command allows you to compile and run your C code in the floaterm window:
 
 ```vim
-:FloatermNew --autoclose=0 gcc % -o %< && ./%<`
+:FloatermNew --autoclose=0 gcc % -o %< && ./%<
 ```
 
 #### `:FloatermPrev` Switch to the previous floaterm instance


### PR DESCRIPTION
My change
```diff
- :FloatermNew --autoclose=0 gcc % -o %< && ./%<`
+ :FloatermNew --autoclose=0 gcc % -o %< && ./%<
```
While reading the documentation I found an extra backtick/backquote in the example codeblock for compiling and running  
C code, which was causing this error in zsh:


![error_report](https://user-images.githubusercontent.com/53875706/99104177-a8e26280-2606-11eb-8a84-4c7205f39d85.png)

Command works as expected after removing the extra backtick.
