### PR TITLE
typo in the function name. correct is floaterm#util#getbuflines

### DIFF
--- a/rplugin/python3/deoplete/source/floaterm.py
+++ b/rplugin/python3/deoplete/source/floaterm.py
@@ -26,7 +26,7 @@ class Source(Base):
         self.max_candidates = 0
 
     def gather_candidates(self, context):
-        lines: List[str] = self.vim.call("floaterm#util#getbufline", -1, 100)
+        lines: List[str] = self.vim.call("floaterm#util#getbuflines", -1, 100)
         candidates = []
         for line in lines:
             for word in line.split(" "):


### PR DESCRIPTION
As agreed.

I fixed small typo in the Python function for Deoplete.

`floaterm#util#getbufline` -> `floaterm#util#getbuflines`

BR,
Alexey