### PR TITLE
Correctly check if job exists with job_status

### DIFF
--- a/autoload/floaterm/terminal.vim
+++ b/autoload/floaterm/terminal.vim
@@ -171,7 +171,7 @@ function! floaterm#terminal#kill(bufnr) abort
     endif
   else
     let job = term_getjob(a:bufnr)
-    if job && job_status(job) !=# 'dead'
+    if job_status(job) && job_status(job) !=# 'dead'
       call job_stop(job)
     endif
   endif

--- a/autoload/floaterm/terminal.vim
+++ b/autoload/floaterm/terminal.vim
@@ -171,7 +171,7 @@ function! floaterm#terminal#kill(bufnr) abort
     endif
   else
     let job = term_getjob(a:bufnr)
-    if job_status(job) && job_status(job) !=# 'dead'
+    if job is not v:null && job_status(job) !=# 'dead'
       call job_stop(job)
     endif
   endif


### PR DESCRIPTION
Avoids error 'Using a Job as a Number'