### PR TITLE
Rework pseudo $EDITOR in floaterm

### DIFF
--- a/README.md
+++ b/README.md
@@ -255,11 +255,12 @@ Available: `'edit'`, `'split'`, `'vsplit'`, `'tabe'`, `'drop'`. Default: `'edit'
 
 #### **`g:floaterm_gitcommit`**
 
-Type `String`. Opening strategy for `COMMIT_EDITMSG` window by running `git commit` in the floaterm window. Only works in neovim.
+Type `String`. Opening strategy for gitcommit window when running `git commit`
+in floaterm.
 
-Available: `'floaterm'`(open `gitcommit` in the floaterm window), `'split'`(recommended), `'vsplit'`, `'tabe'`.
+Available: `'split'`(recommended), `'vsplit'`, `'tabe'`, etc.
 
-Default: `''`, which means this is disabled by default(use your own `$GIT_EDITOR`).
+Default: `'vsplit'`. Set to `''` to disable this feature (use your own `$GIT_EDITOR`).
 
 #### **`g:floaterm_autoclose`**
 
@@ -647,6 +648,9 @@ https://github.com/voldikss/vim-floaterm/issues?q=label%3A%22breaking+change%22
   from [vim-terminal-help](https://github.com/skywind3000/vim-terminal-help/blob/master/tools/utils/drop)
 
 - Some features require [neovim-remote](https://github.com/mhinz/neovim-remote)
+
+- [edita.vim](https://github.com/lambdalisue/edita.vim) for pseudo `$EDITOR` in
+  floaterm
 
 ## License
 

--- a/autoload/floaterm.vim
+++ b/autoload/floaterm.vim
@@ -24,15 +24,7 @@ if stridx($PATH, s:script) < 0
 endif
 
 if !empty(g:floaterm_gitcommit)
-  autocmd FileType gitcommit,gitrebase,gitconfig set bufhidden=delete
-  if g:floaterm_gitcommit == 'floaterm'
-    let $GIT_EDITOR = 'nvr --remote-wait'
-  else
-    let $GIT_EDITOR = printf(
-      \ 'nvr -cc "call floaterm#hide(1, 0, \"\") | %s" --remote-wait',
-      \ g:floaterm_gitcommit
-      \ )
-  endif
+  call floaterm#edita#setup#enable()
 endif
 
 " ----------------------------------------------------------------------------

--- a/autoload/floaterm/edita/neovim/client.vim
+++ b/autoload/floaterm/edita/neovim/client.vim
@@ -1,0 +1,31 @@
+let s:repo = fnamemodify(expand('<sfile>'), ':p:h:h:h:h:h')
+
+function! floaterm#edita#neovim#client#open() abort
+  let server = $NVIM_LISTEN_ADDRESS
+  let mode = floaterm#edita#neovim#util#mode(server)
+  let ch = sockconnect(mode, server, { 'rpc': 1 })
+  let target = fnamemodify(argv()[-1], ':p')
+  let client = serverstart()
+  call rpcrequest(ch, 'nvim_command', printf(
+        \ 'call floaterm#edita#neovim#editor#open("%s", "%s")',
+        \ target,
+        \ client,
+        \))
+endfunction
+
+function! floaterm#edita#neovim#client#EDITOR() abort
+  let args = [
+        \ v:progpath,
+        \ '--headless',
+        \ '--clean',
+        \ '--noplugin',
+        \ '-n',
+        \ '-R',
+        \]
+  let cmds = [
+        \ printf('set runtimepath^=%s', fnameescape(s:repo)),
+        \ 'call floaterm#edita#neovim#client#open()'
+        \]
+  call map(cmds, { -> printf('-c %s', shellescape(v:val)) })
+  return join(args + cmds)
+endfunction

--- a/autoload/floaterm/edita/neovim/editor.vim
+++ b/autoload/floaterm/edita/neovim/editor.vim
@@ -1,0 +1,33 @@
+function! floaterm#edita#neovim#editor#open(target, client)
+  let bufnr = floaterm#buflist#curr()
+  call floaterm#window#hide(bufnr)
+  execute printf('%s %s', g:floaterm_gitcommit, fnameescape(a:target))
+  setlocal bufhidden=wipe
+  augroup edita_buffer
+    autocmd! * <buffer>
+    autocmd BufDelete <buffer> call s:BufDelete()
+  augroup END
+  let mode = floaterm#edita#neovim#util#mode(a:client)
+  let b:edita = sockconnect(mode, a:client, { 'rpc': 1 })
+endfunction
+
+function! s:BufDelete() abort
+  let ch = getbufvar(expand('<afile>'), 'edita', v:null)
+  if ch is# v:null
+    return
+  endif
+  silent! call rpcrequest(ch, 'nvim_command', 'qall')
+endfunction
+
+function! s:VimLeave() abort
+  let expr = v:dying || v:exiting > 0 ? 'cquit' : 'qall'
+  let editas = range(0, bufnr('$'))
+  call map(editas, { -> getbufvar(v:val, 'edita', v:null) })
+  call filter(editas, { -> !empty(v:val) })
+  silent! call map(editas, { -> rpcrequest(v:val, 'nvim_command', expr) })
+endfunction
+
+augroup edita_internal
+  autocmd! *
+  autocmd VimLeave * call s:VimLeave()
+augroup END

--- a/autoload/floaterm/edita/neovim/util.vim
+++ b/autoload/floaterm/edita/neovim/util.vim
@@ -1,0 +1,5 @@
+function! floaterm#edita#neovim#util#mode(address) abort
+  return a:address =~# '^\%(\%(\d\{1,3}\.\)\{3}\d\{1,3}\)\?:\d\+'
+        \ ? 'tcp'
+        \ : 'pipe'
+endfunction

--- a/autoload/floaterm/edita/setup.vim
+++ b/autoload/floaterm/edita/setup.vim
@@ -1,0 +1,30 @@
+let s:EDITOR_SAVED = exists('$EDITOR') ? $EDITOR : v:null
+let s:GIT_EDITOR_SAVED = exists('$GIT_EDITOR') ? $GIT_EDITOR : v:null
+
+
+function! floaterm#edita#setup#EDITOR() abort
+  return has('nvim')
+        \ ? floaterm#edita#neovim#client#EDITOR()
+        \ : floaterm#edita#vim#client#EDITOR()
+endfunction
+
+function! floaterm#edita#setup#enable() abort
+  let editor = floaterm#edita#setup#EDITOR()
+  let $EDITOR = editor
+  let $GIT_EDITOR = editor
+endfunction
+
+" not used 
+function! floaterm#edita#setup#disable() abort
+  if s:EDITOR_SAVED is# v:null
+    unlet $EDITOR
+  else
+    let $EDITOR = s:EDITOR_SAVED
+  endif
+  if s:GIT_EDITOR_SAVED is# v:null
+    unlet $GIT_EDITOR
+  else
+    let $GIT_EDITOR = s:GIT_EDITOR_SAVED
+  endif
+endfunction
+

--- a/autoload/floaterm/edita/vim/client.vim
+++ b/autoload/floaterm/edita/vim/client.vim
@@ -1,0 +1,47 @@
+let s:repo = fnamemodify(expand('<sfile>'), ':p:h:h:h:h:h')
+
+function! floaterm#edita#vim#client#open() abort
+  bwipeout!
+  let target = fnamemodify(argv()[-1], ':p')
+  call s:send(['call', 'floaterm#util#edit_by_editor', target])
+  enew | redraw
+  " Disable mappings to prevent accidental edit
+  for nr in range(256)
+    silent! execute printf("cnoremap \<buffer>\<silent> \<Char-%d> \<Nop>", nr)
+  endfor
+  " Accept 'Editaquit' to quit
+  silent! cnoremap <buffer> Editaquit <C-u>OK<Return>
+  silent! cnoremap <buffer> <C-c> <Esc>
+  let r = input(printf('Waiting %s. Hit Ctrl-C to cancel', target))
+  if !empty(r)
+    quitall!
+  else
+    cquit!
+  endif
+endfunction
+
+function! floaterm#edita#vim#client#EDITOR() abort
+  let args = [
+        \ v:progpath,
+        \ '--not-a-term',
+        \ '--clean',
+        \ '--noplugin',
+        \ '-n',
+        \ '-R',
+        \]
+  let cmds = [
+        \ printf('set runtimepath^=%s', fnameescape(s:repo)),
+        \ 'call floaterm#edita#vim#client#open()'
+        \]
+  call map(cmds, { -> printf('-c %s', shellescape(v:val)) })
+  return join(args + cmds)
+endfunction
+
+function! s:send(data) abort
+  execute "set t_ts=\<Esc>]51; t_fs=\x07"
+  let &titlestring = json_encode(a:data)
+  set title
+  redraw!
+  let &titlestring = ''
+  set t_ts& t_fs&
+endfunction

--- a/autoload/floaterm/edita/vim/editor.vim
+++ b/autoload/floaterm/edita/vim/editor.vim
@@ -1,0 +1,33 @@
+let s:quit_expr = "\<C-\>\<C-n>iEditaquit"
+
+function! floaterm#edita#vim#editor#open(target, bufnr)
+  call floaterm#window#hide(a:bufnr)
+  execute printf('%s %s', g:floaterm_gitcommit, fnameescape(a:target))
+  setlocal bufhidden=wipe
+  augroup edita_buffer
+    autocmd! * <buffer>
+    autocmd BufDelete <buffer> call s:BufDelete()
+  augroup END
+  let b:edita = a:bufnr
+endfunction
+
+function! s:BufDelete() abort
+  let bufnr = getbufvar(expand('<afile>'), 'edita', v:null)
+  if bufnr is# v:null
+    return
+  endif
+  silent! call term_sendkeys(bufnr, s:quit_expr)
+endfunction
+
+function! s:VimLeave() abort
+  let expr = v:dying || v:exiting > 0 ? 'cquit' : 'qall'
+  let editas = range(0, bufnr('$'))
+  call map(editas, { -> getbufvar(v:val, 'edita', v:null) })
+  call filter(editas, { -> !empty(v:val) })
+  silent! call map(editas, { -> term_sendkeys(v:val, s:quit_expr) })
+endfunction
+
+augroup edita_internal
+  autocmd! *
+  autocmd VimLeave * call s:VimLeave()
+augroup END

--- a/autoload/floaterm/terminal.vim
+++ b/autoload/floaterm/terminal.vim
@@ -117,7 +117,7 @@ function! s:spawn_terminal(cmd, jobopts, config) abort
       unlet a:jobopts.on_exit
     endif
     if has('patch-8.1.2080')
-      let a:jobopts.term_api = 'floaterm#util#edit'
+      let a:jobopts.term_api = 'floaterm#util#edit_by_'
     endif
     let a:jobopts.hidden = 1
     try
@@ -186,7 +186,10 @@ function! floaterm#terminal#kill(bufnr) abort
       execute a:bufnr . 'bwipeout!'
     endif
   catch
-    call popup_close(win_getid())
+    try " life is so hard
+      call popup_close(win_getid())
+    catch
+    endtry
   endtry
 endfunction
 

--- a/autoload/floaterm/util.vim
+++ b/autoload/floaterm/util.vim
@@ -33,9 +33,15 @@ function! floaterm#util#show_msg(message, ...) abort
   endif
 endfunction
 
-function! floaterm#util#edit(_bufnr, filename) abort
+" >>> floaterm test.txt
+function! floaterm#util#edit_by_floaterm(_bufnr, filename) abort
   call floaterm#hide(1, 0, '')
   silent execute g:floaterm_open_command . ' ' . a:filename
+endfunction
+
+" >>> $EDITOR test.txt
+function! floaterm#util#edit_by_editor(bufnr, filename) abort
+  call floaterm#edita#vim#editor#open(a:filename, a:bufnr)
 endfunction
 
 function! floaterm#util#startinsert() abort

--- a/bin/floaterm
+++ b/bin/floaterm
@@ -29,13 +29,13 @@ absolute_path() {
 name="$(absolute_path """$1""")"
 
 if [ -z "$NVIM_LISTEN_ADDRESS" ]; then
-    printf '\033]51;["call", "floaterm#util#edit", "%s"]\007' "$name"
+    printf '\033]51;["call", "floaterm#util#edit_by_floaterm", "%s"]\007' "$name"
 else
     if [ -x "$(which nvr 2> /dev/null)" ]; then
         if [ -p /dev/stdin ]; then
             nvr -cc "FloatermHide!" --remote -
         else
-            nvr --servername "$NVIM_LISTEN_ADDRESS" --remote-expr "floaterm#util#edit(0, '$name')"
+            nvr --servername "$NVIM_LISTEN_ADDRESS" --remote-expr "floaterm#util#edit_by_floaterm(0, '$name')"
         fi
     else
         echo "Cannot find nvr executable, please install neovim-remote using pip3"

--- a/bin/floaterm.cmd
+++ b/bin/floaterm.cmd
@@ -13,11 +13,11 @@ if "%NVIM_LISTEN_ADDRESS%" == "" GOTO vim
 goto neovim
 
 :vim
-call "%VIM_EXE%" --servername "%VIM_SERVERNAME%" --remote-expr "floaterm#util#edit(0, '%NAME%')"
+call "%VIM_EXE%" --servername "%VIM_SERVERNAME%" --remote-expr "floaterm#util#edit_by_floaterm(0, '%NAME%')"
 goto end
 
 :neovim
-call "nvr" --servername "%NVIM_LISTEN_ADDRESS%" --remote-expr "floaterm#util#edit(0, '%NAME%')"
+call "nvr" --servername "%NVIM_LISTEN_ADDRESS%" --remote-expr "floaterm#util#edit_by_floaterm(0, '%NAME%')"
 goto end
 
 :nonvr

--- a/doc/floaterm.txt
+++ b/doc/floaterm.txt
@@ -5,7 +5,7 @@ License: MIT license
 NOTE: This doc may be outdated, please refer to the README file instead,
     https://github.com/voldikss/vim-floaterm/blob/master/README.md
     or
-    ../README.md
+    ../README.md(put the cursor on this and type `gf`)
 ==============================================================================
 
 CONTENTS                                         *floaterm-contents*
@@ -18,6 +18,7 @@ Extensions                                       |floaterm-extensions|
 Integrations                                     |floaterm-integrations|
 FAQ                                              |floaterm-faq|
 Repository                                       |floaterm-repository|
+
 ==============================================================================
 INTRODUCTION                                     *floaterm-introduction*
 
@@ -32,6 +33,7 @@ Use (neo)vim terminal in the floating/popup window.
 - Integrate with other external command-line tools(ranger, lf, fzf, etc.)
 - Autocompletion from within floaterms(require |coc.nvim|)
 - Use as a custom task runner for |asynctasks.vim|
+
 ==============================================================================
 OPTIONS                                          *floaterm-options*
 
@@ -98,12 +100,10 @@ g:floaterm_open_command                          *g:floaterm_open_command*
 
 g:floaterm_gitcommit                             *g:floaterm_gitcommit*
 	Type |String|.
-	Opening strategy for `COMMIT_EDITMSG` window by running `git commit` in
-	the floaterm window. Only works in neovim. The value can be
-	'floaterm'(open gitcommit in the floaterm window), 'split'(recommended),
-	'vsplit', 'tabe'.
-	Default value is '', which means this feature is disabled by default(use
-	your own `$GIT_EDITOR`).
+    Opening strategy for gitcommit window when running `git commit`.
+    Available: 'split'(recommended), 'vsplit', 'tabe', etc.
+    Default: 'vsplit'. Set to `''` to disable this feature (use your own
+    `$GIT_EDITOR`).
 
 g:floaterm_autoclose                             *g:floaterm_autoclose*
 	Type |Number|.
@@ -325,48 +325,9 @@ Install voldikss/leaderf-floaterm and run:
 ------------------------------------------------------------------------------
 ASYNCTASKS.VIM                                   *asynctasks.vim*
 
-This plugin can be a runner for |asynctasks.vim|. To use it, copy the
-following code to your `vimrc` set |g:asynctasks_term_pos| to `'floaterm'` or
-add a `pos=floaterm` filed in your asynctasks configuration files.
- >
-    function! s:run_in_floaterm(opts)
-        execute 'FloatermNew --position=bottomright' .
-                        \ ' --wintype=float' .
-                        \ ' --height=0.4' .
-                        \ ' --width=0.4' .
-                        \ ' --title=floaterm_runner' .
-                        \ ' --autoclose=0' .
-                        \ ' --silent=' . get(a:opts, 'silent', 0)
-                        \ ' --cwd=' . a:opts.cwd
-                        \ ' ' . a:opts.cmd
-        " Do not focus on floaterm window, and close it once cursor moves
-        " If you want to jump to the floaterm window, use <C-w>p
-        " You can choose whether to use the following code or not
-        stopinsert | noa wincmd p
-        augroup close-floaterm-runner
-            autocmd!
-            autocmd CursorMoved,InsertEnter * ++nested
-                \ call timer_start(100, { -> s:close_floaterm_runner() })
-        augroup END
-    endfunction
-    function! s:close_floaterm_runner() abort
-        if &ft == 'floaterm' | return | endif
-        for b in tabpagebuflist()
-            if getbufvar(b, '&ft') == 'floaterm' &&
-                \ getbufvar(b, 'floaterm_jobexists') == v:false
-            execute b 'bwipeout!'
-            break
-            endif
-        endfor
-        autocmd! close-floaterm-runner
-    endfunction
-    let g:asyncrun_runner = get(g:, 'asyncrun_runner', {})
-    let g:asyncrun_runner.floaterm = function('s:run_in_floaterm')
-    let g:asynctasks_term_pos = 'floaterm'
-    <
-Then your task will be ran in the floaterm instance. See
-https://github.com/skywind3000/asynctasks.vim/wiki/Customize-Runner for more
-information.
+This plugin can be a runner for |asynctasks.vim| or |asyncrun.vim|. See
+[|asyncrun.extra|](https://github.com/skywind3000/asyncrun.extra) for the
+installation and usage.
 
 ==============================================================================
 INTEGRATIONS                                     *floaterm-integrations*

--- a/plugin/floaterm.vim
+++ b/plugin/floaterm.vim
@@ -73,3 +73,9 @@ call s:bind_keymap(g:floaterm_keymap_hide,   'FloatermHide')
 call s:bind_keymap(g:floaterm_keymap_show,   'FloatermShow')
 call s:bind_keymap(g:floaterm_keymap_kill,   'FloatermKill')
 call s:bind_keymap(g:floaterm_keymap_toggle, 'FloatermToggle')
+
+"-----------------------------------------------------------------------------
+" options broken by breaking changes
+if g:floaterm_gitcommit == 'floaterm'
+  let g:floaterm_gitcommit = 'vsplit'
+endif

--- a/test/test_options/test-gitcommit.vader
+++ b/test/test_options/test-gitcommit.vader
@@ -4,24 +4,13 @@ Execute(Include base):
   source test/base_vader.vim
 
 Execute(FloatermNew git commit --amend):
-  if has('nvim')
-    let g:floaterm_gitcommit = 'split'
-    let pwd = $PWD
-    silent execute printf('!touch %s/afile && git add afile', pwd)
-    FloatermNew git commit
-    sleep 1000m
-
-    " Log $GIT_EDITOR
-    " Log nvim_win_get_config(win_getid())
-    " for l in range(1, line('$'))
-    "   Log getline(l)
-    " endfor
-    "
-    " Log expand('%')
-    " Log &ft
-    Assert !IsInFloatermBuffer()
-    silent execute printf('!cd %s && rm afile && git add afile', pwd)
-  endif
+  let g:floaterm_gitcommit = 'split'
+  let pwd = $PWD
+  silent execute printf('!touch %s/afile && git add afile', pwd)
+  FloatermNew git commit
+  sleep 500m
+  AssertEqual &ft, 'gitcommit' 
+  silent execute printf('!cd %s && rm afile && git add afile', pwd)
 
   FloatermKill!
   stopinsert


### PR DESCRIPTION

* No external dependencies

* Also works for vim8

# breaking changes:

- get rid of `'floaterm`' value of `g:floaterm_gitcommit'`. Fallback: `'vsplit'`.