### PR TITLE
Wrapper api

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,6 @@ Use (neo)vim terminal in the floating/popup window.
   - [How to define more wrappers](#how-to-define-more-wrappers)
   - [How to write sources for fuzzy finder plugins](#how-to-write-sources-for-fuzzy-finder-plugins)
 - [Contributing](#contributing)
-- [Wiki](#wiki)
 - [FAQ](#faq)
 - [Breaking changes](#breaking-changes)
 - [Related projects](#related-projects)
@@ -116,7 +115,7 @@ For example, the command
 :FloatermNew --height=0.6 --width=0.4 --wintype=float --name=floaterm1 --position=topleft --autoclose=2 ranger --cmd="cd ~"
 ```
 
-will open a new floating/popup floaterm instance named `floaterm1` running 
+will open a new floating/popup floaterm instance named `floaterm1` running
 `ranger --cmd="cd ~"` in the `topleft` corner of the main window.
 
 The following command allows you to compile and run your C code in the floaterm window:
@@ -642,23 +641,24 @@ There are two ways for a command to be spawned:
   [fzf wrapper](./autoload/floaterm/wrapper/fzf.vim)
 
   ```vim
-  function! floaterm#wrapper#fzf#() abort
-    return ['floaterm $(fzf)', {}, v:true]
+  function! floaterm#wrapper#fzf#(cmd, jobopts, config) abort
+    return [v:true, 'floaterm $(fzf)']
   endfunction
   ```
 
   The code above returns a list. `floaterm $(fzf)` is the command to be
   executed. `v:true` means the command will be executed after the `&shell`
-  startup. In this way, the second element of the list must be `{}`.
+  startup.
 
 - To be executed through `termopen()`/`term_start()` function, in that case, a
   callback option can be provided. See [fzf wrapper](./autoload/floaterm/wrapper/fzf.vim)
 
   ```vim
-  function! floaterm#wrapper#fzf#(cmd) abort
+  function! floaterm#wrapper#fzf#(cmd, jobopts, config) abort
     let s:fzf_tmpfile = tempname()
     let cmd = a:cmd . ' > ' . s:fzf_tmpfile
-    return [cmd, {'on_exit': funcref('s:fzf_callback')}, v:false]
+    let a:jobopts.on_exit = funcref('s:fzf_callback')
+    return [v:false, cmd]
   endfunction
 
   function! s:fzf_callback(...) abort
@@ -680,13 +680,32 @@ There are two ways for a command to be spawned:
   ```
 
   In the example above, after executing `:FloatermNew fzf`, function
-  `floaterm#wrapper#fzf#` will return `['fzf > /tmp/atmpfilename', {'on_exit': funcref('s:fzf_callback')}, v:false]`.
+  `floaterm#wrapper#fzf#` will return
 
-  Here `v:false` means `cmd`(`fzf > /tmp/atmpfilename`) will be passed through
-  `termopen()`(neovim) or `term_start()`(vim). As a result, an fzf interactive
-  will be opened in a floaterm window. After choosing a file using `<CR>`, fzf
-  exits and the filepath will be written in `/tmp/atmpfilename`. Then the
-  function `s:fzf_callback()` will be invoked to open the file.
+  ```vim
+  [v:false, 'fzf > /tmp/atmpfilename'].
+  ```
+
+  Here `v:false` means `cmd`
+
+  ```vim
+  fzf > /tmp/atmpfilename
+  ```
+
+  will be passed through `termopen()`(neovim) or `term_start()`(vim). As the
+  result, an fzf interactive will be opened in a floaterm window.
+
+  When user picks a file using `ENTER`, fzf exits and the filepath will be
+  written in `/tmp/atmpfilename` and `s:fzf_callback()` will be invoked to
+  open the file. Note that the function `s: fzf_callback()` is registered by
+
+  ```vim
+  let a:jobopts.on_exit = funcref('s:fzf_callback')
+  ```
+
+  The variable `a:jobopts` in the above code will be eventually passed to
+  `termopen()`(neovim) or `term_start()`(vim). For more info, see
+  `:help jobstart-options`(neovim) or `:help job-options`(vim)
 
 ### How to write sources for fuzzy finder plugins
 
@@ -694,16 +713,12 @@ Function `floaterm#buflist#gather()` returns a list contains all the floaterm bu
 
 Function `floaterm#terminal#open_existing({bufnr})` opens the floaterm whose buffer number is `{bufnr}`.
 
-For reference, see [floaterm source for vim-clap](./autoload/clap/provider/floaterm.vim).
+For reference, see [floaterm source for LeaderF](https://github.com/voldikss/LeaderF-floaterm/blob/master/autoload/lf_floaterm.vim).
 
 ## Contributing
 
 - Improve the documentation
 - Help resolve issues labeled as [help wanted](https://github.com/voldikss/vim-floaterm/issues?q=is%3Aissue+label%3A%22help+wanted%22)
-
-## Wiki
-
-https://github.com/voldikss/vim-floaterm/wiki
 
 ## FAQ
 

--- a/autoload/floaterm.vim
+++ b/autoload/floaterm.vim
@@ -45,13 +45,13 @@ function! floaterm#new(bang, cmd, jobopts, config) abort
       try
         let [shell, shellslash, shellcmdflag, shellxquote] = floaterm#util#use_sh_or_cmd()
         let WrapFunc = function(printf('floaterm#wrapper#%s#', maybe_wrapper))
-        let [name, jobopts, send2shell] = WrapFunc(a:cmd)
+        " NOTE: a:jobopts and a:config can be changed in WrapFunc
+        let [send2shell, newcmd] = WrapFunc(a:cmd, a:jobopts, a:config)
         if send2shell
           let bufnr = floaterm#terminal#open(-1, g:floaterm_shell, a:jobopts, a:config)
-          call floaterm#terminal#send(bufnr, [name])
+          call floaterm#terminal#send(bufnr, [newcmd])
         else
-          call floaterm#util#deep_extend(a:jobopts, jobopts)
-          let bufnr = floaterm#terminal#open(-1, name, a:jobopts, a:config)
+          let bufnr = floaterm#terminal#open(-1, newcmd, a:jobopts, a:config)
         endif
       finally
         let [&shell, &shellslash, &shellcmdflag, &shellxquote] = [shell, shellslash, shellcmdflag, shellxquote]

--- a/autoload/floaterm/terminal.vim
+++ b/autoload/floaterm/terminal.vim
@@ -75,7 +75,7 @@ function! floaterm#terminal#open(bufnr, cmd, jobopts, config) abort
   if !bufexists(a:bufnr)
     " change cwd
     let savedcwd = getcwd()
-    let dest = get(a:config, 'cwd', '')
+    let dest = fnamemodify(get(a:config, 'cwd', ''), ':p')
     if dest == '<root>'
       let dest = floaterm#path#get_root()
     endif

--- a/autoload/floaterm/wrapper/fff.vim
+++ b/autoload/floaterm/wrapper/fff.vim
@@ -5,7 +5,7 @@
 " GitHub: https://github.com/benwoodward
 " ============================================================================
 
-function! floaterm#wrapper#fff#(cmd) abort
+function! floaterm#wrapper#fff#(cmd, jobopts, config) abort
   let original_dir = getcwd()
   lcd %:p:h
 
@@ -19,7 +19,9 @@ function! floaterm#wrapper#fff#(cmd) abort
 
   exe "lcd " . original_dir
   let cmd = [&shell, &shellcmdflag, cmd]
-  return [cmd, {'on_exit': funcref('s:fff_callback')}, v:false]
+  let jobopts = {'on_exit': funcref('s:fff_callback')}
+  call floaterm#util#deep_extend(a:jobopts, jobopts)
+  return [v:false, cmd]
 endfunction
 
 function! s:fff_callback(job, data, event, opener) abort

--- a/autoload/floaterm/wrapper/fzf.vim
+++ b/autoload/floaterm/wrapper/fzf.vim
@@ -5,7 +5,7 @@
 " GitHub: https://github.com/voldikss
 " ============================================================================
 
-function! floaterm#wrapper#fzf#(cmd) abort
+function! floaterm#wrapper#fzf#(cmd, jobopts, config) abort
   let s:fzf_tmpfile = tempname()
   let cmd = a:cmd
   if cmd !~ '--preview'
@@ -17,7 +17,9 @@ function! floaterm#wrapper#fzf#(cmd) abort
   endif
   let cmd .= ' > ' . s:fzf_tmpfile
   let cmd = [&shell, &shellcmdflag, cmd]
-  return [cmd, {'on_exit': funcref('s:fzf_callback')}, v:false]
+  let jobopts = {'on_exit': funcref('s:fzf_callback')}
+  call floaterm#util#deep_extend(a:jobopts, jobopts)
+  return [v:false, cmd]
 endfunction
 
 function! s:fzf_callback(job, data, event, opener) abort

--- a/autoload/floaterm/wrapper/lf.vim
+++ b/autoload/floaterm/wrapper/lf.vim
@@ -5,7 +5,7 @@
 " GitHub: https://github.com/benwoodward
 " ============================================================================
 
-function! floaterm#wrapper#lf#(cmd) abort
+function! floaterm#wrapper#lf#(cmd, jobopts, config) abort
   let s:lf_tmpfile = tempname()
   let original_dir = getcwd()
   lcd %:p:h
@@ -20,7 +20,9 @@ function! floaterm#wrapper#lf#(cmd) abort
 
   exe "lcd " . original_dir
   let cmd = [&shell, &shellcmdflag, cmd]
-  return [cmd, {'on_exit': funcref('s:lf_callback')}, v:false]
+  let jobopts = {'on_exit': funcref('s:lf_callback')}
+  call floaterm#util#deep_extend(a:jobopts, jobopts)
+  return [v:false, cmd]
 endfunction
 
 function! s:lf_callback(job, data, event, opener) abort

--- a/autoload/floaterm/wrapper/nnn.vim
+++ b/autoload/floaterm/wrapper/nnn.vim
@@ -5,7 +5,7 @@
 " GitHub: https://github.com/voldikss
 " ============================================================================
 
-function! floaterm#wrapper#nnn#(cmd) abort
+function! floaterm#wrapper#nnn#(cmd, jobopts, config) abort
   let s:nnn_tmpfile = tempname()
   let original_dir = getcwd()
   lcd %:p:h
@@ -20,7 +20,9 @@ function! floaterm#wrapper#nnn#(cmd) abort
 
   exe "lcd " . original_dir
   let cmd = [&shell, &shellcmdflag, cmd]
-  return [cmd, {'on_exit': funcref('s:nnn_callback')}, v:false]
+  let jobopts = {'on_exit': funcref('s:nnn_callback')}
+  call floaterm#util#deep_extend(a:jobopts, jobopts)
+  return [v:false, cmd]
 endfunction
 
 function! s:nnn_callback(job, data, event, opener) abort

--- a/autoload/floaterm/wrapper/ranger.vim
+++ b/autoload/floaterm/wrapper/ranger.vim
@@ -5,7 +5,7 @@
 " GitHub: https://github.com/voldikss
 " ============================================================================
 
-function! floaterm#wrapper#ranger#(cmd) abort
+function! floaterm#wrapper#ranger#(cmd, jobopts, config) abort
   let s:ranger_tmpfile = tempname()
   let original_dir = getcwd()
   lcd %:p:h
@@ -15,16 +15,20 @@ function! floaterm#wrapper#ranger#(cmd) abort
   if len(cmdlist) > 1
     let cmd .= ' ' . join(cmdlist[1:], ' ')
   else
-    if expand('%:p') != ''
-      let cmd .= ' --selectfile="' . expand('%:p') . '"'
-    else
-    let cmd .= ' "' . getcwd() . '"'
+    if !has_key(a:config, 'cwd')
+      if expand('%:p') != ''
+        let cmd .= ' --selectfile="' . expand('%:p') . '"'
+      else
+        let cmd .= ' "' . getcwd() . '"'
+      endif
     endif
   endif
 
   exe "lcd " . original_dir
   let cmd = [&shell, &shellcmdflag, cmd]
-  return [cmd, {'on_exit': funcref('s:ranger_callback')}, v:false]
+  let jobopts = {'on_exit': funcref('s:ranger_callback')}
+  call floaterm#util#deep_extend(a:jobopts, jobopts)
+  return [v:false, cmd]
 endfunction
 
 function! s:ranger_callback(job, data, event, opener) abort

--- a/autoload/floaterm/wrapper/rg.vim
+++ b/autoload/floaterm/wrapper/rg.vim
@@ -13,7 +13,7 @@ else
   let s:viewer = 'cat -n'
 endif
 
-function! floaterm#wrapper#rg#(cmd) abort
+function! floaterm#wrapper#rg#(cmd, jobopts, config) abort
   let FZF_DEFAULT_COMMAND = "rg --column --line-number --no-heading --color=always --smart-case -- " . shellescape('')
 
   let s:rg_tmpfile = tempname()
@@ -30,11 +30,12 @@ function! floaterm#wrapper#rg#(cmd) abort
         \ ]
   let cmd = printf('%s %s > %s', prog, join(arglist), s:rg_tmpfile)
   let cmd = [&shell, &shellcmdflag, cmd]
-  return [
-        \ cmd,
-        \ {'on_exit': funcref('s:rg_callback'), 'env': {'FZF_DEFAULT_COMMAND': FZF_DEFAULT_COMMAND}},
-        \ v:false
-        \ ]
+  let jobopts = {
+        \ 'on_exit': funcref('s:rg_callback'),
+        \ 'env': {'FZF_DEFAULT_COMMAND': FZF_DEFAULT_COMMAND}
+        \ } 
+  call floaterm#util#deep_extend(a:jobopts, jobopts)
+  return [v:false, cmd]
 endfunction
 
 function! s:rg_callback(job, data, event, opener) abort

--- a/autoload/floaterm/wrapper/vifm.vim
+++ b/autoload/floaterm/wrapper/vifm.vim
@@ -5,7 +5,7 @@
 " GitHub: https://github.com/kazhala
 " ============================================================================
 
-function! floaterm#wrapper#vifm#(cmd) abort
+function! floaterm#wrapper#vifm#(cmd, jobopts, config) abort
   let s:vifm_tmpfile = tempname()
   let original_dir = getcwd()
   lcd %:p:h
@@ -20,7 +20,9 @@ function! floaterm#wrapper#vifm#(cmd) abort
 
   exe "lcd " . original_dir
   let cmd = [&shell, &shellcmdflag, cmd]
-  return [cmd, {'on_exit': funcref('s:vifm_callback')}, v:false]
+  let jobopts = {'on_exit': funcref('s:vifm_callback')}
+  call floaterm#util#deep_extend(a:jobopts, jobopts)
+  return [v:false, cmd]
 endfunction
 
 function! s:vifm_callback(job, data, event, opener) abort


### PR DESCRIPTION
## Breaking changes

- function arguments change

  ```vim
  floaterm#wrapper#xxx#(cmd)
  ```

  was changed to

  ```vim
  floaterm#wrapper#xxx#(cmd, jobopts, config)
  ```

- return value

  ```vim
  return [cmd, {'on_exit': funcref('s:xxx_callback')}, v:false]
  ```

  was changed to

  ```vim
  return [v:false, cmd]
  ```

  and there is one more line

  ```vim
  let a:jobopts.on_exit = funcref('s:xxx_callback')
  ```
