### PR TITLE
Add option to start floaterm in dir of active buffer

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,8 +79,9 @@ external terminals.
   attributes of a specific floaterm instance. Note that in order to input
   space, you have to form it as `\` followed by space, and `\` must be typed
   as `\\`
-  - `cwd` working directory that floaterm will be opened at, accept either a
-    path or literal `<root>` which represents the project root directory
+  - `cwd` working directory that floaterm will be opened at. Accepts a
+    path, the literal `<root>` which represents the project root directory, and
+    the literal `<buffer>` which specifies the directory of the active buffer
   - `name` name of the floaterm
   - `silent` If `--silent` is given, spawn a floaterm but not open the window,
     you may toggle it afterwards

--- a/autoload/floaterm/cmdline.vim
+++ b/autoload/floaterm/cmdline.vim
@@ -32,6 +32,8 @@ function! floaterm#cmdline#parse(argstr) abort
           if key == 'cwd'
             if value == '<root>'
               let value = floaterm#path#get_root()
+            elseif value == '<buff>'
+              let value = expand('%:p:h')
             else
               let value = fnamemodify(value, ':p')
             endif

--- a/autoload/floaterm/cmdline.vim
+++ b/autoload/floaterm/cmdline.vim
@@ -32,7 +32,7 @@ function! floaterm#cmdline#parse(argstr) abort
           if key == 'cwd'
             if value == '<root>'
               let value = floaterm#path#get_root()
-            elseif value == '<buff>'
+            elseif value == '<buffer>'
               let value = expand('%:p:h')
             else
               let value = fnamemodify(value, ':p')


### PR DESCRIPTION
Based on [this](https://www.reddit.com/r/neovim/comments/kh33rc/is_it_possible_to_open_floaterm_in_cwd_of_current/) post, I'm not the only one interested in this functionality.

This PR proposes a minimalistic way to solve this. Let me know what you think. If you like the idea, I can also update the docs.