### PR TITLE
Use double quotes for ripgrep

### DIFF
--- a/autoload/floaterm/wrapper/rg.vim
+++ b/autoload/floaterm/wrapper/rg.vim
@@ -20,7 +20,7 @@ function! floaterm#wrapper#rg#(cmd, jobopts, config) abort
         \ "--line-number",
         \ "--no-heading",
         \ "--color=always",
-        \ "--smart-case ''",
+        \ "--smart-case \"\"",
         \ join(split(a:cmd)[1:])
         \ ])
 


### PR DESCRIPTION
While all other shells work nicely with both single and double-quotes, cmd on Windows only likes double quotes. 

This is a simple fix that will likely not affect other shells.