### PR TITLE
Fix floaterm.cmd

### DIFF
--- a/bin/floaterm.cmd
+++ b/bin/floaterm.cmd
@@ -2,7 +2,6 @@
 setlocal EnableDelayedExpansion
 
 if "%1" == "" GOTO help
-if "%VIM_EXE%" == "" GOTO missing
 
 REM Get absolute name
 for /f "delims=" %%i in ("%1") do set "NAME=%%~fi"
@@ -12,6 +11,7 @@ if "%NVIM_LISTEN_ADDRESS%" == "" GOTO vim
 goto neovim
 
 :vim
+if "%VIM_EXE%" == "" GOTO missing
 call "%VIM_EXE%" --servername "%VIM_SERVERNAME%" --remote-expr "Tapi_edita_open(bufnr(), ['%NAME%'])"
 goto end
 


### PR DESCRIPTION
The floaterm command was always failing on Neovim because VIM_EXE is never defined on Neovim.

So the check for VIM_EXE variable should be put inside the `:vim` function.

The command `floaterm filename.txt` works on Neovim now.