### PR TITLE
remove empty pattern

### DIFF
--- a/autoload/floaterm/wrapper/rg.vim
+++ b/autoload/floaterm/wrapper/rg.vim
@@ -20,7 +20,7 @@ function! floaterm#wrapper#rg#(cmd, jobopts, config) abort
         \ "--line-number",
         \ "--no-heading",
         \ "--color=always",
-        \ "--smart-case \"\"",
+        \ "--smart-case",
         \ join(split(a:cmd)[1:])
         \ ])
 


### PR DESCRIPTION
### What?
Reduce noise by preventing `ripgrep` to matching everything
### Why?
Since `ripgrep` gets an empty pattern it matches every file which is then passed to FZF.
I'm not sure was it on purpose but because of this, there is a lot of noise for further `fzf` filtering.
### How?
Remove empty args from ripgrep call. 
### Testing?
Manually
### Screenshots (optional)
### Anything Else?
