### PR TITLE
docs: Change 'guibg' to 'guifg' in FloatermNC Example

### DIFF
--- a/README.md
+++ b/README.md
@@ -371,8 +371,8 @@ no-current-focused window(`:help NormalNC`).
 ```vim
 " Configuration example
 
-" Set floaterm window background to gray once the cursor moves out from it
-hi FloatermNC guibg=gray
+" Set floaterm window foreground to gray once the cursor moves out from it
+hi FloatermNC guifg=gray
 ```
 
 <details>


### PR DESCRIPTION
Hi 👋 

I noticed an inconsistency in the README.md where the `FloatermNC` configuration example didn't match the demo shown. 
Hope this small fix is okay!