### PR TITLE
feat: Add an option to disable floaterm's GIT_EDITOR override

### DIFF
--- a/README.md
+++ b/README.md
@@ -260,6 +260,13 @@ Type `List` of `String`. Markers used to detect the project root directory for `
 
 Default: `['.project', '.git', '.hg', '.svn', '.root']`
 
+#### **`g:floaterm_giteditor`**
+
+Type `Boolean`. Whether to override `$GIT_EDITOR` in floaterm terminals so git commands can
+open open an editor in the same neovim instance. See [git](#git) for details.
+
+Default: `v:true`
+
 #### **`g:floaterm_opener`**
 
 Type `String`. Command used for opening a file in the outside nvim from within `:terminal`.
@@ -418,6 +425,8 @@ P.S.
 #### [git](https://git-scm.com/)
 
 Execute `git commit` in the terminal window without starting a nested vim/nvim.
+
+Refer to [g:floaterm_giteditor](#gfloaterm_giteditor) to disable this behavior.
 
 Refer to [g:floaterm_opener](#gfloaterm_opener) for configurable open action
 

--- a/autoload/floaterm/util.vim
+++ b/autoload/floaterm/util.vim
@@ -154,7 +154,9 @@ function! floaterm#util#setenv() abort
   endif
   let editor = floaterm#edita#setup#EDITOR()
   let env.FLOATERM = editor
-  let env.GIT_EDITOR = editor
+  if g:floaterm_giteditor
+    let env.GIT_EDITOR = editor
+  endif
   return env
 endfunction
 

--- a/plugin/floaterm.vim
+++ b/plugin/floaterm.vim
@@ -25,6 +25,8 @@ let g:floaterm_position         = get(g:, 'floaterm_position', 'center')
 let g:floaterm_borderchars      = get(g:, 'floaterm_borderchars', '─│─│┌┐┘└')
 let g:floaterm_rootmarkers      = get(g:, 'floaterm_rootmarkers', ['.project', '.git', '.hg', '.svn', '.root'])
 let g:floaterm_opener           = get(g:, 'floaterm_opener', 'split')
+let g:floaterm_giteditor        = get(g:, 'floaterm_giteditor', v:true)
+
 
 command! -nargs=* -complete=customlist,floaterm#cmdline#complete -bang -range
                           \ FloatermNew    call floaterm#run('new', <bang>0, [visualmode(), <range>, <line1>, <line2>], <q-args>)


### PR DESCRIPTION
With setting g:floaterm_giteditor = 0 (which defaults to 1),
floaterm's git editor integration is disabled and `$GIT_EDITOR`
won't be overriden.
