### PR TITLE
fix(broot): use redirect to file instead of --out

### DIFF
--- a/autoload/floaterm/wrapper/broot.vim
+++ b/autoload/floaterm/wrapper/broot.vim
@@ -30,7 +30,7 @@ function! floaterm#wrapper#broot#(cmd, jobopts, config) abort
 
   let cmdlist = split(a:cmd)
   let cmd = printf(
-        \ '%s --conf "%s" --out "%s"',
+        \ '%s --conf "%s" > "%s"',
         \ a:cmd,
         \ s:broot_confpath,
         \ s:broot_tmpfile


### PR DESCRIPTION
There is no more `--out` command in `broot`.

The new `--outcmd` option does not write to file when `:print_filename` is called.

Fix it by redirecting `broot` output to the tmp file used in `--out` option.