### PR TITLE
feat(broot): use line number from broot search

### DIFF
--- a/autoload/floaterm/util.vim
+++ b/autoload/floaterm/util.vim
@@ -40,7 +40,13 @@ endfunction
 " - a:0: String, opening action, default `g:floaterm_opener`
 function! floaterm#util#open(locations, ...) abort
   let opener = get(a:000, 0, g:floaterm_opener)
-  execute opener a:locations[0].filename
+  let loc = a:locations[0]
+  execute opener loc.filename
+  if has_key(loc, 'lnum')
+    execute loc.lnum
+  elseif has_key(loc, 'text')
+    execute '/' . loc.text
+  endif
   for loc in a:locations[1:]
     execute 'edit ' loc.filename
     if has_key(loc, 'lnum')

--- a/autoload/floaterm/wrapper/broot.vim
+++ b/autoload/floaterm/wrapper/broot.vim
@@ -15,7 +15,8 @@ let s:broot_wrapper_config = [
       \ '		{',
       \ '			invocation: terminal',
       \ '			key: enter',
-      \ '			execution: ":print_path"',
+      \ '			execution: "echo {line} {file}"',
+      \ '			leave_broot: true',
       \ '			apply_to: file',
       \ '		}',
       \ '	]',
@@ -52,7 +53,11 @@ function! s:broot_callback(job, data, event, opener) abort
       endif
       let locations = []
       for filename in filenames
-        let dict = {'filename': fnamemodify(filename, ':p')}
+        let lnum_file = split(filename)
+        let dict = {
+              \ 'filename': fnamemodify(lnum_file[1], ':p'),
+              \ 'lnum': lnum_file[0],
+              \ }
         call add(locations, dict)
       endfor
       call floaterm#util#open(locations, a:opener)


### PR DESCRIPTION
Pass on line number as broot allow to search for text in files (e.g. `c/printf`) and provides line number of the selected match. Along the way fix `floaterm#util#open` as it was ignoring `lnum` and `text` of the first entry in `locations`.