### PR TITLE
docs(readme): add requirements section to ripgrep

### DIFF
--- a/README.md
+++ b/README.md
@@ -453,6 +453,10 @@ command! FZF FloatermNew fzf
 
 #### [ripgrep](https://github.com/BurntSushi/ripgrep)
 
+_Requirements_:
+
+- [fzf](https://github.com/junegunn/fzf)
+
 This plugin has implemented a [wrapper](./autoload/floaterm/wrapper/rg.vim)
 for `rg` command.
 


### PR DESCRIPTION
When you will try to call `:FloatermNew rg` without pre-installed `fzf` the window will blink without any output