### PR TITLE
feat: add title position option

### DIFF
--- a/README.md
+++ b/README.md
@@ -312,7 +312,7 @@ Type `String`. The position of the floaterm title.
 
 Available: `'left'`, `'center'`, `'right'`.
 
-Default: `left`
+Default: `'left'`
 
 ### Keymaps
 

--- a/README.md
+++ b/README.md
@@ -102,6 +102,7 @@ external terminals.
   - `position` see `g:floaterm_position`
   - `autoclose` see `g:floaterm_autoclose`
   - `borderchars` see `g:floaterm_borderchars`
+  - `titleposition` see `g:floaterm_titleposition`
 - This command basically shares the consistent behaviors with the builtin `:terminal`:
   - The special characters(`:help cmdline-special`) such as `%` and `<cfile>`
     will be auto-expanded, to get standalone characters, use `\` followed by
@@ -304,6 +305,14 @@ Default: `1`.
 Type `Boolean`. Whether to enter Terminal-mode after opening a floaterm.
 
 Default: `v:true`
+
+#### **`g:floaterm_titleposition`**
+
+Type `String`. The position of the floaterm title.
+
+Available: `'left'`, `'center'`, `'right'`.
+
+Default: `left`
 
 ### Keymaps
 

--- a/autoload/floaterm/buffer.vim
+++ b/autoload/floaterm/buffer.vim
@@ -27,7 +27,20 @@ function! floaterm#buffer#create_border_buf(options) abort
   let title_width = strdisplaywidth(title)
   let borderchars = a:options.borderchars
   let [c_top, c_right, c_bottom, c_left, c_topleft, c_topright, c_botright, c_botleft] = borderchars
-  let content = [c_topleft . title . repeat(c_top, repeat_width - title_width) . c_topright]
+  let content = []
+  if a:options.titleposition == 'center'
+    " Align title to center
+    " Shift left if the number of fill characters is odd
+    let nb_fill_char = repeat_width - title_width
+    let side_width = nb_fill_char / 2.0
+    let left_width = float2nr(floor(side_width))
+    let right_width = float2nr(ceil(side_width))
+    let content += [c_topleft . repeat(c_top, left_width) . title . repeat(c_top, right_width) . c_topright]
+  elseif a:options.titleposition == 'right'
+    let content += [c_topleft . repeat(c_top, repeat_width - title_width) . title . c_topright]
+  else " Default align to the left
+    let content += [c_topleft . title . repeat(c_top, repeat_width - title_width) . c_topright]
+  endif
   let content += repeat([c_left . repeat(' ', repeat_width) . c_right], repeat_height)
   let content += [c_botleft . repeat(c_bottom, repeat_width) . c_botright]
   return floaterm#buffer#create_scratch_buf(content)

--- a/autoload/floaterm/cmdline.vim
+++ b/autoload/floaterm/cmdline.vim
@@ -76,6 +76,7 @@ function! floaterm#cmdline#complete(arg_lead, cmd_line, cursor_pos) abort
     \ '--position=',
     \ '--autoclose=',
     \ '--borderchars=',
+    \ '--titleposition=',
     \ '--silent',
     \ '--disposable',
     \ ]
@@ -120,6 +121,8 @@ function! floaterm#cmdline#complete(arg_lead, cmd_line, cursor_pos) abort
   elseif match(a:arg_lead, '--title=') > -1
     return []
   elseif match(a:arg_lead, '--borderchars=') > -1
+    return []
+  elseif match(a:arg_lead, '--titleposition=') > -1
     return []
   elseif match(a:arg_lead, '--position=') > -1
     let wintype = matchstr(a:cmd_line, '--wintype=\zs\w\+\ze')

--- a/autoload/floaterm/config.vim
+++ b/autoload/floaterm/config.vim
@@ -39,14 +39,15 @@ endfunction
 " @return: config, generated from `a:config`, has more additional info, used to
 "   config the floaterm style
 function! floaterm#config#parse(bufnr, config) abort
-  let a:config.title       = get(a:config, 'title', g:floaterm_title)
-  let a:config.width       = get(a:config, 'width', g:floaterm_width)
-  let a:config.height      = get(a:config, 'height', g:floaterm_height)
-  let a:config.opener      = get(a:config, 'opener', g:floaterm_opener)
-  let a:config.wintype     = get(a:config, 'wintype', floaterm#window#win_gettype())
-  let a:config.position    = get(a:config, 'position', g:floaterm_position)
-  let a:config.autoclose   = get(a:config, 'autoclose', g:floaterm_autoclose)
-  let a:config.borderchars = get(a:config, 'borderchars', g:floaterm_borderchars)
+  let a:config.title          = get(a:config, 'title', g:floaterm_title)
+  let a:config.width          = get(a:config, 'width', g:floaterm_width)
+  let a:config.height         = get(a:config, 'height', g:floaterm_height)
+  let a:config.opener         = get(a:config, 'opener', g:floaterm_opener)
+  let a:config.wintype        = get(a:config, 'wintype', floaterm#window#win_gettype())
+  let a:config.position       = get(a:config, 'position', g:floaterm_position)
+  let a:config.autoclose      = get(a:config, 'autoclose', g:floaterm_autoclose)
+  let a:config.borderchars    = get(a:config, 'borderchars', g:floaterm_borderchars)
+  let a:config.titleposition  = get(a:config, 'titleposition', g:floaterm_titleposition)
 
   " Edge cases
   if type(a:config.height) == v:t_number && a:config.height < 3

--- a/autoload/floaterm/window.vim
+++ b/autoload/floaterm/window.vim
@@ -151,7 +151,6 @@ function! s:open_popup(bufnr, config) abort
         \ 'maxheight': a:config.height - 2,
         \ 'minheight': a:config.height - 2,
         \ 'title': a:config.title,
-        \ 'titleposition': a:config.titleposition,
         \ 'border': [1, 1, 1, 1],
         \ 'borderchars': a:config.borderchars,
         \ 'borderhighlight': ['FloatermBorder'],

--- a/autoload/floaterm/window.vim
+++ b/autoload/floaterm/window.vim
@@ -151,6 +151,7 @@ function! s:open_popup(bufnr, config) abort
         \ 'maxheight': a:config.height - 2,
         \ 'minheight': a:config.height - 2,
         \ 'title': a:config.title,
+        \ 'titleposition': a:config.titleposition,
         \ 'border': [1, 1, 1, 1],
         \ 'borderchars': a:config.borderchars,
         \ 'borderhighlight': ['FloatermBorder'],

--- a/doc/floaterm.txt
+++ b/doc/floaterm.txt
@@ -125,7 +125,7 @@ g:floaterm_titleposition                        *g:floaterm_titleposition*
     Type |String|.
     The position of the floaterm title.
     Available: 'left', 'center', 'right'
-    Default value is |left|.
+    Default value is 'left'.
 
 ==============================================================================
 MAPPINGS                                         *floaterm-mappings*

--- a/doc/floaterm.txt
+++ b/doc/floaterm.txt
@@ -121,6 +121,12 @@ g:floaterm_autoinsert                            *g:floaterm_autoinsert*
 	Whether to enter |Terminal-mode| after opening a floaterm.
 	Default value is |v:true|.
 
+g:floaterm_titleposition                        *g:floaterm_titleposition*
+    Type |String|.
+    The position of the floaterm title.
+    Available: 'left', 'center', 'right'
+    Default value is |left|.
+
 ==============================================================================
 MAPPINGS                                         *floaterm-mappings*
 

--- a/plugin/floaterm.vim
+++ b/plugin/floaterm.vim
@@ -26,6 +26,7 @@ let g:floaterm_borderchars      = get(g:, 'floaterm_borderchars', '─│─│�
 let g:floaterm_rootmarkers      = get(g:, 'floaterm_rootmarkers', ['.project', '.git', '.hg', '.svn', '.root'])
 let g:floaterm_opener           = get(g:, 'floaterm_opener', 'split')
 let g:floaterm_giteditor        = get(g:, 'floaterm_giteditor', v:true)
+let g:floaterm_titleposition    = get(g:, 'floaterm_titleposition', 'left')
 
 
 command! -nargs=* -complete=customlist,floaterm#cmdline#complete -bang -range

--- a/test/test_functions/test-floaterm_cmdline.vader
+++ b/test/test_functions/test-floaterm_cmdline.vader
@@ -94,6 +94,7 @@ Execute(Test floaterm#cmdline#complete):
         \ '--position=',
         \ '--autoclose=',
         \ '--borderchars=',
+        \ '--titleposition=',
         \ '--silent',
         \ '--disposable',
         \ ]
@@ -162,7 +163,8 @@ Execute(Test floaterm#cmdline#complete):
         \ '--wintype=1 '.
         \ '--position=1 '.
         \ '--autoclose=1 '.
-        \ '--borderchars=1 ', sort(getcompletion('', 'shellcmd')))
+        \ '--borderchars=1 '.
+        \ '--titleposition=1 ', sort(getcompletion('', 'shellcmd')))
   call Test__floaterm_cmdline_complete('FloatermUpdate ', all_candidates)
   call Test__floaterm_cmdline_complete('FloatermUpdate -', all_candidates)
   call Test__floaterm_cmdline_complete('FloatermUpdate --', all_candidates)
@@ -179,7 +181,8 @@ Execute(Test floaterm#cmdline#complete):
         \ '--wintype=1 '.
         \ '--position=1 '.
         \ '--autoclose=1 '.
-        \ '--borderchars=1 ', [])
+        \ '--borderchars=1 '.
+        \ '--titleposition=1 ', [])
 
 Execute(Test floaterm#cmdline#complete_names1):
   FloatermNew --name=floaterm
@@ -201,3 +204,5 @@ Execute(Test floaterm#cmdline#complete_names2):
 
   FloatermKill!
   stopinsert
+
+

--- a/test/test_options/test-title-position.vader
+++ b/test/test_options/test-title-position.vader
@@ -1,0 +1,31 @@
+" vim:ft=vim
+
+Execute(test-titleposition):
+  function! GetTitleTopline() abort
+    if has('nvim')
+      let bd_winid = getbufvar(bufnr('%'), 'floaterm_borderwinid')
+      return getbufline(winbufnr(bd_winid), 1)[0]
+    else
+      return popup_getoptions(win_getid()).title
+    endif
+  endfunction
+
+  Log 'left-align'
+    FloatermNew --title=title --titleposition=left
+    Assert GetTitleTopline() =~ '^.title'
+
+  Log 'right-align'
+    FloatermNew --title=title --titleposition=right
+    Assert GetTitleTopline() =~ 'title.$'
+
+  Log 'center - even width'
+    FloatermNew --width=8 --title=1234 --titleposition=center
+    Assert GetTitleTopline() =~ '..1234..'
+
+  Log 'center - odd width'
+    FloatermNew --width=8 --title=123 --titleposition=center
+    Assert GetTitleTopline() =~ '..123...'
+
+  FloatermKill!
+  stopinsert
+


### PR DESCRIPTION
Hello,

I would like to add `--titleposition` option to set the position of the floaterm title.

This change add `left` (default), `center` and `right` position, it should be feasible to also add `top` and `bottom` options.

Example:
| left | center | right |
|:----:|:--------:|:------:|
| ![left](https://github.com/voldikss/vim-floaterm/assets/6067072/c11a7c21-acb1-4d65-923d-9b7bceb764b4) | ![center](https://github.com/voldikss/vim-floaterm/assets/6067072/ae29ca9f-1068-41fa-9c93-8b23b04614e8) | ![right](https://github.com/voldikss/vim-floaterm/assets/6067072/77336ecd-ac27-4ade-ac35-2ebc86220382) |