### PR TITLE
fix: set --titleposition functional for vim popup

### DIFF
--- a/autoload/floaterm/buffer.vim
+++ b/autoload/floaterm/buffer.vim
@@ -20,27 +20,34 @@ function! floaterm#buffer#create_scratch_buf(...) abort
   return bufnr
 endfunction
 
-function! floaterm#buffer#create_border_buf(options) abort
-  let repeat_width = a:options.width - 2
-  let repeat_height = a:options.height - 2
+function! floaterm#buffer#create_top_border(options, width) abort
+  let c_top = a:options.borderchars[0]
   let title = a:options.title
   let title_width = strdisplaywidth(title)
-  let borderchars = a:options.borderchars
-  let [c_top, c_right, c_bottom, c_left, c_topleft, c_topright, c_botright, c_botleft] = borderchars
-  let content = []
+  let nb_fill_char = a:width - title_width
+  let top_border = title
   if a:options.titleposition == 'center'
     " Align title to center
     " Shift left if the number of fill characters is odd
-    let nb_fill_char = repeat_width - title_width
     let side_width = nb_fill_char / 2.0
     let left_width = float2nr(floor(side_width))
     let right_width = float2nr(ceil(side_width))
-    let content += [c_topleft . repeat(c_top, left_width) . title . repeat(c_top, right_width) . c_topright]
+    let top_border = repeat(c_top, left_width) . title . repeat(c_top, right_width)
   elseif a:options.titleposition == 'right'
-    let content += [c_topleft . repeat(c_top, repeat_width - title_width) . title . c_topright]
+    let top_border = repeat(c_top, nb_fill_char) . title
   else " Default align to the left
-    let content += [c_topleft . title . repeat(c_top, repeat_width - title_width) . c_topright]
+    let top_border = title . repeat(c_top, nb_fill_char)
   endif
+  return top_border
+endfunction
+
+function! floaterm#buffer#create_border_buf(options) abort
+  let repeat_width = a:options.width - 2
+  let repeat_height = a:options.height - 2
+  let borderchars = a:options.borderchars
+  let [_, c_right, c_bottom, c_left, c_topleft, c_topright, c_botright, c_botleft] = borderchars
+  let top_line = floaterm#buffer#create_top_border(a:options, repeat_width)
+  let content = [c_topleft . top_line . c_topright]
   let content += repeat([c_left . repeat(' ', repeat_width) . c_right], repeat_height)
   let content += [c_botleft . repeat(c_bottom, repeat_width) . c_botright]
   return floaterm#buffer#create_scratch_buf(content)

--- a/autoload/floaterm/window.vim
+++ b/autoload/floaterm/window.vim
@@ -142,6 +142,10 @@ function! s:open_float(bufnr, config) abort
 endfunction
 
 function! s:open_popup(bufnr, config) abort
+  let title = a:config.title
+  if a:config.titleposition != 'left'
+    let title = floaterm#buffer#create_top_border(a:config, a:config.width)
+  endif
   let options = {
         \ 'pos': a:config.anchor,
         \ 'line': a:config.row,
@@ -150,7 +154,7 @@ function! s:open_popup(bufnr, config) abort
         \ 'minwidth': a:config.width - 2,
         \ 'maxheight': a:config.height - 2,
         \ 'minheight': a:config.height - 2,
-        \ 'title': a:config.title,
+        \ 'title': title,
         \ 'border': [1, 1, 1, 1],
         \ 'borderchars': a:config.borderchars,
         \ 'borderhighlight': ['FloatermBorder'],

--- a/test/test_options/test-title-position.vader
+++ b/test/test_options/test-title-position.vader
@@ -12,19 +12,35 @@ Execute(test-titleposition):
 
   Log 'left-align'
     FloatermNew --title=title --titleposition=left
-    Assert GetTitleTopline() =~ '^.title'
+    if has('nvim')
+      Assert GetTitleTopline() =~ '^.title'
+    else
+      Assert GetTitleTopline() =~ '^title'
+    endif
 
   Log 'right-align'
     FloatermNew --title=title --titleposition=right
-    Assert GetTitleTopline() =~ 'title.$'
+    if has('nvim')
+      Assert GetTitleTopline() =~ 'title.$'
+    else
+      Assert GetTitleTopline() =~ 'title$'
+    endif
 
   Log 'center - even width'
     FloatermNew --width=8 --title=1234 --titleposition=center
-    Assert GetTitleTopline() =~ '..1234..'
+    if has('nvim')
+      Assert GetTitleTopline() =~ '..1234..'
+    else
+      Assert GetTitleTopline() =~ '.1234.'
+    endif
 
   Log 'center - odd width'
     FloatermNew --width=8 --title=123 --titleposition=center
-    Assert GetTitleTopline() =~ '..123...'
+    if has('nvim')
+      Assert GetTitleTopline() =~ '..123...'
+    else
+      Assert GetTitleTopline() =~ '.123..'
+    endif
 
   FloatermKill!
   stopinsert


### PR DESCRIPTION
Hello,

I noticed with CI that my previous feature (#410 ) only worked with neovim. 
So I added some modification and refactoring to enable it for vim popup.

This do not introduce any behavior change with default `--titleposition=left` when calling `popup_getoptions(win_getid()).title`. 
Nonetheless for `center` and `right` the vim popup title include borderchars and might be inconsistent with title when using `left` alignment.

I'm not familiar with vim popup, so a better solution may exist.
Let me know what you think and feel free to edit the PR.

Note: CI pass in https://github.com/lucobellic/vim-floaterm/actions/runs/4968353492