### PR TITLE
Use haslocaldir() to choose which flavor of cd to use

### DIFF
--- a/autoload/floaterm/path.vim
+++ b/autoload/floaterm/path.vim
@@ -136,9 +136,6 @@ function! floaterm#path#get_root() abort
 endfunction
 
 function! floaterm#path#chdir(path) abort
-  if exists(":tcd") == 2
-    silent execute 'tcd '. fnameescape(a:path)
-  else
-    silent execute 'cd '. fnameescape(a:path)
-  endif
+  let l:cd = { 0: 'cd', 1: 'lcd', 2: 'tcd' }[haslocaldir()]
+  silent execute l:cd . fnameescape(a:path)
 endfunction


### PR DESCRIPTION
```
haslocaldir([{winnr} [, {tabnr}]])			*haslocaldir()*
		The result is a Number:
		    1   when the window has set a local directory via |:lcd|
		    2   when the tab-page has set a local directory via |:tcd|
		    0   otherwise.

		Without arguments use the current window.
		With {winnr} use this window in the current tab page.
		With {winnr} and {tabnr} use the window in the specified tab
		page.
		{winnr} can be the window number or the |window-ID|.
		If {winnr} is -1 it is ignored and only the tabpage is used.
		Return 0 if the arguments are invalid.
		Examples: >
			if haslocaldir() == 1
			  " window local directory case
			elseif haslocaldir() == 2
			  " tab-local directory case
			else
			  " global directory case
			endif

			" current window
			:echo haslocaldir()
			:echo haslocaldir(0)
			:echo haslocaldir(0, 0)
			" window n in current tab page
			:echo haslocaldir(n)
			:echo haslocaldir(n, 0)
			" window n in tab page m
			:echo haslocaldir(n, m)
			" tab page m
			:echo haslocaldir(-1, m)
```