### PR TITLE
fix:space after cd

### DIFF
--- a/autoload/floaterm/path.vim
+++ b/autoload/floaterm/path.vim
@@ -137,5 +137,5 @@ endfunction
 
 function! floaterm#path#chdir(path) abort
   let l:cd = { 0: 'cd', 1: 'lcd', 2: 'tcd' }[haslocaldir()]
-  silent execute l:cd . fnameescape(a:path)
+  silent execute l:cd . ' ' . fnameescape(a:path)
 endfunction


### PR DESCRIPTION
Error after FloatermNew command in window. Error seem because there is no space after cd. Neovim message showed: 
`Error detected while processing function floaterm#run[7]..floaterm#new[36]..floaterm#terminal#open[22]..floaterm#path#chdir:
line    2:
E492: Not an editor command: cdC:\Users\xxx`
This fix has not tested against linux, but I think this error not too complex.