### PR TITLE
feat: add `--cwd=<buffer-root>` option

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,8 +87,10 @@ external terminals.
   space, you have to form it as `\` followed by space, and `\` must be typed
   as `\\`
   - `cwd` working directory that floaterm will be opened at. Accepts a
-    path, the literal `<root>` which represents the project root directory, and
-    the literal `<buffer>` which specifies the directory of the active buffer
+    path, the literal `<root>` which represents the project root directory,
+    the literal `<buffer>` which specifies the directory of the active buffer,
+    or the literal `<buffer-root>` which corresponds to the project root
+    directory of the active buffer.
   - `name` name of the floaterm
   - `silent` If `--silent` is given, spawn a floaterm but not open the window,
     you may toggle it afterwards
@@ -258,6 +260,7 @@ Default: `─│─│┌┐┘└`
 #### **`g:floaterm_rootmarkers`**
 
 Type `List` of `String`. Markers used to detect the project root directory for `--cwd=<root>`
+or `--cwd=<buffer-root>`.
 
 Default: `['.project', '.git', '.hg', '.svn', '.root']`
 

--- a/autoload/floaterm/cmdline.vim
+++ b/autoload/floaterm/cmdline.vim
@@ -31,9 +31,11 @@ function! floaterm#cmdline#parse(argstr) abort
           let [key, value] = [pair[0][2:], pair[1]]
           if key == 'cwd'
             if value == '<root>'
-              let value = floaterm#path#get_root()
+              let value = floaterm#path#get_root(getcwd())
             elseif value == '<buffer>'
               let value = expand('%:p:h')
+            elseif value == '<buffer-root>'
+              let value = floaterm#path#get_root(expand('%:p:h'))
             else
               let value = fnamemodify(value, ':p')
             endif
@@ -109,7 +111,7 @@ function! floaterm#cmdline#complete(arg_lead, cmd_line, cursor_pos) abort
     let prestr = matchstr(a:arg_lead, '--cwd=\zs.*\ze')
     let dirs = getcompletion(prestr, 'dir')
     if a:arg_lead == '--cwd='
-      let dirs = ['<buffer>', '<root>'] + dirs
+      let dirs = ['<buffer>', '<root>', '<buffer-root>'] + dirs
     endif
     return map(dirs, { k,v -> '--cwd=' . v })
   elseif match(a:arg_lead, '--name=') > -1

--- a/autoload/floaterm/path.vim
+++ b/autoload/floaterm/path.vim
@@ -126,7 +126,7 @@ function! s:path_join(home, name) abort
   endif
 endfunction
 
-function! floaterm#path#get_root(path = getcwd()) abort
+function! floaterm#path#get_root(path=getcwd()) abort
   let strict = 0
   let l:hr = s:find_root(a:path, g:floaterm_rootmarkers, strict)
   if s:is_windows

--- a/autoload/floaterm/path.vim
+++ b/autoload/floaterm/path.vim
@@ -126,9 +126,9 @@ function! s:path_join(home, name) abort
   endif
 endfunction
 
-function! floaterm#path#get_root() abort
+function! floaterm#path#get_root(path = getcwd()) abort
   let strict = 0
-  let l:hr = s:find_root(getcwd(), g:floaterm_rootmarkers, strict)
+  let l:hr = s:find_root(a:path, g:floaterm_rootmarkers, strict)
   if s:is_windows
     let l:hr = s:string_replace(l:hr, '/', "\\")
   endif


### PR DESCRIPTION
This PR adds a literal for the `--cwd` option, namely `<buffer-root>`, which represents the project root directory of the active buffer. This fits my use case, and possibly others I hope, like when editing config files for my vim/neovim placed in a dedicated repository while I'm working on a regular project.