### PR TITLE
fix: Support `git revise --interactive`

### DIFF
--- a/autoload/floaterm/edita/neovim/editor.vim
+++ b/autoload/floaterm/edita/neovim/editor.vim
@@ -8,6 +8,7 @@ function! floaterm#edita#neovim#editor#open(target, client)
   if index([
         \ 'COMMIT_EDITMSG',
         \ 'git-rebase-todo',
+        \ 'git-revise-todo',
         \ 'addp-hunk-edit.diff'
         \ ], expand('%:t')) > -1
     setlocal bufhidden=wipe

--- a/autoload/floaterm/edita/vim/editor.vim
+++ b/autoload/floaterm/edita/vim/editor.vim
@@ -8,6 +8,7 @@ function! floaterm#edita#vim#editor#open(target, bufnr)
   if index([
         \ 'COMMIT_EDITMSG',
         \ 'git-rebase-todo',
+        \ 'git-revise-todo',
         \ 'addp-hunk-edit.diff'
         \ ], expand('%:t')) > -1
     setlocal bufhidden=wipe


### PR DESCRIPTION
[`git-revise`](https://github.com/mystor/git-revise) is an external Git tool mimicking `git-rebase`. It operates in-memory and also offers a `cut` command for splitting commits. It has an interactive mode just like `git-rebase`.

Currently, attempting `git revise --interactive` from floaterm fails, because `$EDITOR` is called with the TODO file and exits immediately.

This PR adds `git-revise-todo` to the search list in `floaterm#edita#{neo,}vim#editor#open`.