### PR TITLE
use exepath of progname in case progpath erroneous

### DIFF
--- a/autoload/floaterm/edita/vim/client.vim
+++ b/autoload/floaterm/edita/vim/client.vim
@@ -22,7 +22,8 @@ endfunction
 
 function! floaterm#edita#vim#client#EDITOR() abort
   let args = [
-        \ shellescape(v:progpath),
+        \ shellescape(fnamemodify(v:progpath, ':t') ==# v:progname ?
+        \             v:progpath : exepath(v:progname)),
         \ '--not-a-term',
         \ '--clean',
         \ '--noplugin',


### PR DESCRIPTION
fixes https://github.com/voldikss/vim-floaterm/issues/349 where gvim was opened in terminal vim