### PR TITLE
stop bufenter from autoinserting

### DIFF
--- a/autoload/floaterm/terminal.vim
+++ b/autoload/floaterm/terminal.vim
@@ -15,7 +15,6 @@ function! s:on_floaterm_create(bufnr) abort
     autocmd! * <buffer>
     autocmd! User FloatermOpen
     autocmd User FloatermOpen call floaterm#util#startinsert()
-    autocmd BufEnter <buffer> call floaterm#util#startinsert()
     execute printf(
           \ 'autocmd BufHidden,BufWipeout <buffer=%s> call floaterm#window#hide(%s)',
           \ a:bufnr,


### PR DESCRIPTION
When scrolling huge file, losing focus makes floatterm lose its last cursor position due to startinsert.
this branch removes bufenter event from calling startinsert logic
