### PR TITLE
fix chdir function for nvim

### DIFF
--- a/autoload/floaterm/path.vim
+++ b/autoload/floaterm/path.vim
@@ -136,6 +136,10 @@ function! floaterm#path#get_root(path=getcwd()) abort
 endfunction
 
 function! floaterm#path#chdir(path) abort
-  let l:cd = { 0: 'cd', 1: 'lcd', 2: 'tcd' }[haslocaldir()]
+  if has('nvim')
+    let l:cd = haslocaldir()? 'lcd' : (haslocaldir(-1, 0)? 'tcd' : 'cd')
+  else
+    let l:cd = { 0: 'cd', 1: 'lcd', 2: 'tcd' }[haslocaldir()]
+  endif
   silent execute l:cd . ' ' . fnameescape(a:path)
 endfunction


### PR DESCRIPTION
sort of fix for issue #423 
`haslocaldir()` function works differently on neovim

```vim
haslocaldir([{winnr} [, {tabnr}]])                               *haslocaldir()*
		The result is a Number, which is 1 when the window has set a
		local path via |:lcd| or when {winnr} is -1 and the tabpage
		has set a local path via |:tcd|, otherwise 0.
```

but to be real I do not understand why floaterm need to call `:cd` or `:tcd` command.
what is the purpose of changing editor(other windows) cwd when opening terminal? 🤔
wouldn’t it be enough just to use `:lcd` for floaterm window? 🤔 