### PR TITLE
fix: respect winborder option which introduced since neovim 0.11

### DIFF
--- a/autoload/floaterm/window.vim
+++ b/autoload/floaterm/window.vim
@@ -111,11 +111,18 @@ function! s:winexists(winid) abort
 endfunction
 
 function! s:open_float(bufnr, config) abort
+  let row = a:config.row + (a:config.anchor[0] == 'N' ? 1 : -1)
+  let col = a:config.col + (a:config.anchor[1] == 'W' ? 1 : -1)
+  if exists('&winborder') && &winborder !=# '' && &winborder !=# 'none'
+    let row = a:config.row
+    let col = a:config.col
+  end
+
   let options = {
         \ 'relative': 'editor',
         \ 'anchor': a:config.anchor,
-        \ 'row': a:config.row + (a:config.anchor[0] == 'N' ? 1 : -1),
-        \ 'col': a:config.col + (a:config.anchor[1] == 'W' ? 1 : -1),
+        \ 'row': row,
+        \ 'col': col,
         \ 'width': a:config.width - 2,
         \ 'height': a:config.height - 2,
         \ 'style':'minimal',
@@ -124,20 +131,22 @@ function! s:open_float(bufnr, config) abort
   call s:init_win(winid, v:false)
   call floaterm#config#set(a:bufnr, 'winid', winid)
 
-  let bd_options = {
-        \ 'relative': 'editor',
-        \ 'anchor': a:config.anchor,
-        \ 'row': a:config.row,
-        \ 'col': a:config.col,
-        \ 'width': a:config.width,
-        \ 'height': a:config.height,
-        \ 'focusable': v:false,
-        \ 'style':'minimal',
-        \ }
-  let bd_bufnr = floaterm#buffer#create_border_buf(a:config)
-  let bd_winid = nvim_open_win(bd_bufnr, v:false, bd_options)
-  call s:init_win(bd_winid, v:true)
-  call floaterm#config#set(a:bufnr, 'borderwinid', bd_winid)
+  if !(exists('&winborder') && &winborder !=# '' && &winborder !=# 'none')
+    let bd_options = {
+          \ 'relative': 'editor',
+          \ 'anchor': a:config.anchor,
+          \ 'row': a:config.row,
+          \ 'col': a:config.col,
+          \ 'width': a:config.width,
+          \ 'height': a:config.height,
+          \ 'focusable': v:false,
+          \ 'style':'minimal',
+          \ }
+    let bd_bufnr = floaterm#buffer#create_border_buf(a:config)
+    let bd_winid = nvim_open_win(bd_bufnr, v:false, bd_options)
+    call s:init_win(bd_winid, v:true)
+    call floaterm#config#set(a:bufnr, 'borderwinid', bd_winid)
+  end
   return winid
 endfunction
 


### PR DESCRIPTION
Hi @voldikss, thanks for creating so awesome plugin. it makes me work on the terminal so happy.

Neovim 0.11 had introduced a new global option named [winborder](https://github.com/neovim/neovim/pull/31074). And vim-floaterm had drawn the border by creating an extra border window now, it's duplicated if I set winborder as rounded

![PixPin_2025-05-14_11-13-03](https://github.com/user-attachments/assets/91448584-54ee-4d0d-885a-1ede91d939f8)

this pr fixes it by cancel creating an extra border window.

the window screenshot is below if the user hasn't set [winborder]

![PixPin_2025-05-14_11-12-28](https://github.com/user-attachments/assets/b10e25c9-85d6-4f57-a6ae-f2912669c19f)

the window screenshot is below if the user has set [winborder]

![image](https://github.com/user-attachments/assets/4b483e39-6513-43d9-8f56-5a439c11536e)
