### PR TITLE
Un-silence checktime of floaterm#window#hide

### DIFF
--- a/autoload/floaterm/window.vim
+++ b/autoload/floaterm/window.vim
@@ -266,7 +266,7 @@ function! floaterm#window#hide(bufnr) abort
       endtry
     endif
   endif
-  silent checktime
+  checktime
 endfunction
 
 " find **one** visible floaterm window


### PR DESCRIPTION
If deleting a file, either from within floaterm itself or while floaterm is open, the `silent` will silence the 'E211 File "{filename}" no longer available' error if floaterm is hidden before another call to `:checktime` is made. A common situation when this can happen is when using floaterm to check out a branch that doesn't contain all the files currently being edited.

Given that it's not possible to just add another :checktime to re-trigger the E211 error (since the original :checktime has updated the timestamps), it seems appropriate to expect those who don't want the possible (n)vim output resulting from a :checktime to explicitly silence suppress it to avoid forcing those who do want the output to resort to custom workarounds.

I noticed [this](https://github.com/voldikss/vim-floaterm/issues/178) conversation. It mentions `:checktime`, but I don't see it specifically requiring `silent`, so I was hoping that it can be removed as in this PR since it's a bit inconvenient not being notified about files that are no longer available.