### PR TITLE
fix: support Vim 8.0 without default argument values

### DIFF
--- a/autoload/floaterm/path.vim
+++ b/autoload/floaterm/path.vim
@@ -126,9 +126,10 @@ function! s:path_join(home, name) abort
   endif
 endfunction
 
-function! floaterm#path#get_root(path=getcwd()) abort
+function! floaterm#path#get_root(...) abort
+  let l:path = a:0 > 0 ? a:1 : getcwd()
   let strict = 0
-  let l:hr = s:find_root(a:path, g:floaterm_rootmarkers, strict)
+  let l:hr = s:find_root(l:path, g:floaterm_rootmarkers, strict)
   if s:is_windows
     let l:hr = s:string_replace(l:hr, '/', "\\")
   endif


### PR DESCRIPTION
Fix for #453.
Older Vim versions (e.g., 8.0.1763) do not support default values in function definitions.
Replace the default argument with vararg to maintain compatibility.