### PR TITLE
 master adapt to health api change in 0.11.0 - neovim/neovim@c08b030 

### DIFF
--- a/autoload/health/floaterm.vim
+++ b/autoload/health/floaterm.vim
@@ -8,18 +8,18 @@
 let s:home = fnamemodify(resolve(expand('<sfile>:p')), ':h:h:h')
 
 function! s:check_common() abort
-  call health#report_start('common')
-  call health#report_info('Platform: ' . s:get_platform_info())
-  call health#report_info('Nvim: ' . s:get_nvim_info())
-  call health#report_info('Plugin: ' . s:get_plugin_info())
+  call health#start('common')
+  call health#info('Platform: ' . s:get_platform_info())
+  call health#info('Nvim: ' . s:get_nvim_info())
+  call health#info('Plugin: ' . s:get_plugin_info())
 endfunction
 
 function! s:check_terminal() abort
-  call health#report_start('terminal')
+  call health#start('terminal')
   if exists(':terminal') > 0
-    call health#report_ok('Terminal emulator is available')
+    call health#ok('Terminal emulator is available')
   else
-    call health#report_error(
+    call health#error(
           \ 'Terminal emulator is missing',
           \ ['Install the latest version neovim']
           \ )
@@ -27,11 +27,11 @@ function! s:check_terminal() abort
 endfunction
 
 function! s:check_floating() abort
-  call health#report_start('floating')
+  call health#start('floating')
   if exists('*nvim_win_set_config')
-    call health#report_ok('Floating window is available')
+    call health#ok('Floating window is available')
   else
-    call health#report_warn(
+    call health#warn(
           \ 'Floating window is missing, will fallback to use normal window',
           \ ['Install the latest version neovim']
           \ )

--- a/autoload/health/floaterm.vim
+++ b/autoload/health/floaterm.vim
@@ -8,18 +8,18 @@
 let s:home = fnamemodify(resolve(expand('<sfile>:p')), ':h:h:h')
 
 function! s:check_common() abort
-  call health#start('common')
-  call health#info('Platform: ' . s:get_platform_info())
-  call health#info('Nvim: ' . s:get_nvim_info())
-  call health#info('Plugin: ' . s:get_plugin_info())
+  call vim.health.start('common')
+  call vim.health.info('Platform: ' . s:get_platform_info())
+  call vim.health.info('Nvim: ' . s:get_nvim_info())
+  call vim.health.info('Plugin: ' . s:get_plugin_info())
 endfunction
 
 function! s:check_terminal() abort
-  call health#start('terminal')
+  call vim.health.start('terminal')
   if exists(':terminal') > 0
-    call health#ok('Terminal emulator is available')
+    call vim.health.ok('Terminal emulator is available')
   else
-    call health#error(
+    call vim.health.error(
           \ 'Terminal emulator is missing',
           \ ['Install the latest version neovim']
           \ )
@@ -27,11 +27,11 @@ function! s:check_terminal() abort
 endfunction
 
 function! s:check_floating() abort
-  call health#start('floating')
+  call vim.health.start('floating')
   if exists('*nvim_win_set_config')
-    call health#ok('Floating window is available')
+    call vim.health.ok('Floating window is available')
   else
-    call health#warn(
+    call vim.health.warn(
           \ 'Floating window is missing, will fallback to use normal window',
           \ ['Install the latest version neovim']
           \ )


### PR DESCRIPTION
The previous commit d9fc8d0e90393d9182e6e62ebe696e33030b96c2 was not correct. Fix it by this one - [7abc47d](https://github.com/voldikss/vim-floaterm/pull/459/commits/7abc47de268069d319c338544cfe035466b485fa).