### PR TITLE
feat: add support for `JJ_EDITOR` similar to `GIT_EDITOR`

### DIFF
--- a/README.md
+++ b/README.md
@@ -268,7 +268,7 @@ Default: `['.project', '.git', '.hg', '.svn', '.root']`
 
 Type `Boolean`. Whether to override `$GIT_EDITOR` in floaterm terminals so git commands can
 open open an editor in the same neovim instance. See [git](#git) for details.
-This flag also overrides `$HGEDITOR` for Mercurial.
+This flag also overrides `$HGEDITOR` for Mercurial and `JJ_EDITOR` for Jujutsu.
 
 Default: `v:true`
 

--- a/autoload/floaterm/edita/neovim/editor.vim
+++ b/autoload/floaterm/edita/neovim/editor.vim
@@ -12,7 +12,9 @@ function! floaterm#edita#neovim#editor#open(target, client)
         \ 'git-rebase-todo',
         \ 'git-revise-todo',
         \ 'addp-hunk-edit.diff',
-        \ ], filename) > -1) || (stridx(filename, 'commit.hg.txt') > -1)
+        \ ], filename) > -1) ||
+    \ (stridx(filename, 'commit.hg.txt') > -1) ||
+    \ (stridx(filename, '.jjdescription') > -1)
     setlocal bufhidden=wipe
     augroup edita_buffer
       autocmd! * <buffer>

--- a/autoload/floaterm/edita/vim/editor.vim
+++ b/autoload/floaterm/edita/vim/editor.vim
@@ -12,7 +12,9 @@ function! floaterm#edita#vim#editor#open(target, bufnr)
         \ 'git-rebase-todo',
         \ 'git-revise-todo',
         \ 'addp-hunk-edit.diff',
-        \ ], filename) > -1) || (stridx(filename, 'commit.hg.txt') > -1)
+        \ ], filename) > -1) ||
+    \ (stridx(filename, 'commit.hg.txt') > -1) ||
+    \ (stridx(filename, '.jjdescription') > -1)
     setlocal bufhidden=wipe
     augroup edita_buffer
       autocmd! * <buffer>

--- a/autoload/floaterm/util.vim
+++ b/autoload/floaterm/util.vim
@@ -163,6 +163,7 @@ function! floaterm#util#setenv() abort
   if g:floaterm_giteditor
     let env.GIT_EDITOR = editor
     let env.HGEDITOR = editor
+    let env.JJ_EDITOR = editor
   endif
   return env
 endfunction


### PR DESCRIPTION
On a similar note:
Going through the code I noticed the growing list of string matches against file names, for this specific mechanism (i.e. blocking the terminal until buffer is closed).
Wouldn't it, at this point, make sense to have a separate switch to keep the terminal instance waiting? Maybe even expose it, so it can be used in conjuction with other programs, instead of hardcoding in that behavior for certain file names.
What's the general opinion on that?

(I'm not entirely sure how to solve that in an elegant way -- I have a toy example that appends a fake file named "WAIT" to `GIT_EDITOR` (etc.) and uses that as a "flag", preserving the behavior of the `floaterm` command, just to test it out. That is certainly not a satisfying solution.)